### PR TITLE
Fix link to clojars on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Leona
 _Pen or sword - the shield is mightiest  - Leona_
 
-[![Clojars Project](https://img.shields.io/clojars/v/leona.svg)](https://clojars.org/leona)
-[![CircleCI](https://circleci.com/gh/WorksHub/leona.svg?style=svg)](https://circleci.com/gh/WorksHub/leona)
+[![Clojars Project](https://img.shields.io/clojars/v/workshub/leona.svg)](https://clojars.org/workshub/leona) [![CircleCI](https://circleci.com/gh/WorksHub/leona.svg?style=svg)](https://circleci.com/gh/WorksHub/leona)
 
 A toolbox designed to make working with GraphQL and clojure.spec a more pleasant experience.
 


### PR DESCRIPTION
Point to the new location of clojars library: `workshub/leona`