### PR TITLE
Add _input to the name of input objects

### DIFF
--- a/src/leona/core.clj
+++ b/src/leona/core.clj
@@ -187,12 +187,14 @@
 ;;;;;
 
 (defn transform-input-object-key [k]
+  "Adds a suffix '_input_' to the provided keyword k"
   (-> k
       name
       (str "_input")
       keyword))
 
 (defn transform-input-object-keys [m]
+  "Given the map m, transforms all its keys using the transform-input-object-key function"
   (->> m
        (map (fn [[k v]]
               [(transform-input-object-key k)
@@ -200,6 +202,7 @@
        (into {})))
 
 (defn replace-input-objects [m input-objects]
+  "Given a map and map of input objects, replaces instances of input-object types with their transformed form"
   (walk/postwalk
     (fn [d]
       (if-let [match (some #(when (or (= d {:type %})

--- a/src/leona/core.clj
+++ b/src/leona/core.clj
@@ -202,17 +202,17 @@
 (defn replace-input-objects [m input-objects]
   (walk/postwalk
     (fn [d]
-      (if-let [match (some #(when (or
-                                        (= d {:type %})
-                                        (= d {:type (list 'non-null %)}))
+      (if-let [match (some #(when (or (= d {:type %})
+                                      (= d {:type (list 'non-null %)}))
                               %)
-                                 (keys input-objects))]
-        (walk/postwalk (fn [m]
-                         (if (= m match)
-                           (transform-input-object-key m)
-                           m))
-                       d)
-              d))
+                           (keys input-objects))]
+        (walk/postwalk
+          (fn [n]
+            (if (= n match)
+              (transform-input-object-key n)
+              n))
+          d)
+        d))
     m))
 
 (defn generate

--- a/src/leona/core.clj
+++ b/src/leona/core.clj
@@ -204,13 +204,13 @@
 (defn replace-input-objects [m input-objects]
   "Given a map and map of input objects, replaces instances of input-object types with their transformed form"
   (walk/postwalk
-    (fn [d]
+    (fn replace-input-object-types [d]
       (if-let [match (some #(when (or (= d {:type %})
                                       (= d {:type (list 'non-null %)}))
                               %)
                            (keys input-objects))]
         (walk/postwalk
-          (fn [n]
+          (fn replace-matched-type [n]
             (if (= n match)
               (transform-input-object-key n)
               n))

--- a/src/leona/core.clj
+++ b/src/leona/core.clj
@@ -219,17 +219,17 @@
   "Takes pre-compiled data structure and converts it into a Lacinia schema"
   [m]
   {:pre [(s/valid? ::pre-compiled-data m)]}
-  (let [queries (generate-root-objects (:queries m) :query-spec :query)
-        mutations (generate-root-objects (:mutations m) :mutation-spec :mutation)
+  (let [queries       (generate-root-objects (:queries m) :query-spec :query)
+        mutations     (generate-root-objects (:mutations m) :mutation-spec :mutation)
         input-objects (merge (extract-input-objects queries) (extract-input-objects mutations))]
     (cond-> (apply leona-schema/combine (:specs m))
-      queries (assoc :queries (-> queries
-                                  (dissoc-input-objects)
-                                  (replace-input-objects input-objects)))
-      mutations (assoc :mutations (-> mutations
-                                      (dissoc-input-objects)
-                                      (replace-input-objects input-objects)))
-      input-objects (assoc :input-objects (transform-input-object-keys input-objects))
+      queries                          (assoc :queries (-> queries
+                                                           (dissoc-input-objects)
+                                                           (replace-input-objects input-objects)))
+      mutations                        (assoc :mutations (-> mutations
+                                                             (dissoc-input-objects)
+                                                             (replace-input-objects input-objects)))
+      input-objects                    (assoc :input-objects (transform-input-object-keys input-objects))
       (not-empty (:field-resolvers m)) (inject-field-resolvers (:field-resolvers m)))))
 
 (defn compile

--- a/src/leona/core.clj
+++ b/src/leona/core.clj
@@ -186,17 +186,50 @@
 
 ;;;;;
 
+(defn transform-input-object-key [k]
+  (-> k
+      name
+      (str "_input")
+      keyword))
+
+(defn transform-input-object-keys [m]
+  (->> m
+       (map (fn [[k v]]
+              [(transform-input-object-key k)
+               v]))
+       (into {})))
+
+(defn replace-input-objects [m input-objects]
+  (walk/postwalk
+    (fn [d]
+      (if-let [match (some #(when (or
+                                        (= d {:type %})
+                                        (= d {:type (list 'non-null %)}))
+                              %)
+                                 (keys input-objects))]
+        (walk/postwalk (fn [m]
+                         (if (= m match)
+                           (transform-input-object-key m)
+                           m))
+                       d)
+              d))
+    m))
+
 (defn generate
   "Takes pre-compiled data structure and converts it into a Lacinia schema"
   [m]
   {:pre [(s/valid? ::pre-compiled-data m)]}
-  (let [queries       (generate-root-objects (:queries m)   :query-spec    :query)
-        mutations     (generate-root-objects (:mutations m) :mutation-spec :mutation)
+  (let [queries (generate-root-objects (:queries m) :query-spec :query)
+        mutations (generate-root-objects (:mutations m) :mutation-spec :mutation)
         input-objects (merge (extract-input-objects queries) (extract-input-objects mutations))]
     (cond-> (apply leona-schema/combine (:specs m))
-      queries                          (assoc :queries       (dissoc-input-objects queries))
-      mutations                        (assoc :mutations     (dissoc-input-objects mutations))
-      input-objects                    (assoc :input-objects input-objects)
+      queries (assoc :queries (-> queries
+                                  (dissoc-input-objects)
+                                  (replace-input-objects input-objects)))
+      mutations (assoc :mutations (-> mutations
+                                      (dissoc-input-objects)
+                                      (replace-input-objects input-objects)))
+      input-objects (assoc :input-objects (transform-input-object-keys input-objects))
       (not-empty (:field-resolvers m)) (inject-field-resolvers (:field-resolvers m)))))
 
 (defn compile

--- a/test/leona/core_test.clj
+++ b/test/leona/core_test.clj
@@ -162,7 +162,7 @@
         compiled-schema (-> (leona/create)
                             (leona/attach-query ::test-query ::test resolver)
                             (leona/compile))
-        result (leona/execute compiled-schema "query Test($input: input!) { test(input: $input) { num }}" {:input {:num 1, :nums [2 3]}} {})]
+        result (leona/execute compiled-schema "query Test($input: input_input!) { test(input: $input) { num }}" {:input {:num 1, :nums [2 3]}} {})]
     (is (= 6 (get-in result [:data :test :num])))))
 
 ;;;;;


### PR DESCRIPTION
We infer `input-objects` directly from the spec, but we can have a conflict with objects if they have the same name. With this PR the input objects have automatically the `_input` added to it.