### PR TITLE
Fix for input objects being called from other input objects

### DIFF
--- a/src/leona/core.clj
+++ b/src/leona/core.clj
@@ -205,16 +205,18 @@
   "Given a map and map of input objects, replaces instances of input-object types with their transformed form"
   (walk/postwalk
     (fn replace-input-object-types [d]
-      (if-let [match (some #(when (or (= d {:type %})
-                                      (= d {:type (list 'non-null %)}))
-                              %)
-                           (keys input-objects))]
-        (walk/postwalk
-          (fn replace-matched-type [n]
-            (if (= n match)
-              (transform-input-object-key n)
-              n))
-          d)
+      (if (and (map? d)
+               (contains? d :type))
+        (if (keyword? (:type d))
+          (if (some #(= (:type d) %) (keys input-objects))
+            (update d :type transform-input-object-key)
+            d)
+          (walk/postwalk
+            (fn replace-matched-type [n] ;; {:type ;..... }
+              (if (some #(= n %) (keys input-objects))
+                (transform-input-object-key n)
+                n))
+            d))
         d))
     m))
 

--- a/src/leona/core.clj
+++ b/src/leona/core.clj
@@ -232,7 +232,9 @@
       mutations                        (assoc :mutations (-> mutations
                                                              (dissoc-input-objects)
                                                              (replace-input-objects input-objects)))
-      input-objects                    (assoc :input-objects (transform-input-object-keys input-objects))
+      input-objects                    (assoc :input-objects (-> input-objects
+                                                                 (transform-input-object-keys)
+                                                                 (replace-input-objects input-objects)))
       (not-empty (:field-resolvers m)) (inject-field-resolvers (:field-resolvers m)))))
 
 (defn compile

--- a/test/leona/core_test.clj
+++ b/test/leona/core_test.clj
@@ -185,6 +185,28 @@
                               {:test_query {:input {:num 1, :nums [2 3]}}} {})]
     (is (= 6 (get-in result [:data :test :num])))))
 
+
+;;;;;
+
+(deftest input-objects-nested-list
+  (s/def ::num int?)
+  (s/def ::nums (s/coll-of ::num))
+  (s/def ::input (s/keys :req-un [::num ::nums]))
+  (s/def ::args (s/keys :req-un [::input]))
+  (s/def ::test (s/keys :req-un [::num]))
+  (s/def ::inputs (s/coll-of ::input))
+  (s/def ::test-query (s/keys :req-un [::inputs]))
+  (let [resolver (fn [ctx query value]
+                   (let [{:keys [num nums]} (first (:inputs query))]
+                     {:num (apply + num nums)}))
+        compiled-schema (-> (leona/create)
+                            (leona/attach-query ::test-query ::test resolver)
+                            (leona/compile))
+        result (leona/execute compiled-schema "query Test($inputs: [input_input!]!) { test(inputs: $inputs) { num }}" {:inputs [{:num 1, :nums [2 3]}]} {})]
+    (is (= 6 (get-in result [:data :test :num])))))
+
+
+
 ;;;;;
 
 (deftest middleware-test


### PR DESCRIPTION
This is similar to #18 , but it includes `input_objects`, as they might reference another input_object.

Furthermore, we improved the matcher so it will match over arbitrary nesting of `list` and `non-null`