### PR TITLE
Update automatic name conversion to use `PascalCase`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Leona
-_Pen or sword - the shield is mightiest  - Leona_
+
+_Pen or sword - the shield is mightiest - Leona_
 
 [![Clojars Project](https://img.shields.io/clojars/v/workshub/leona.svg)](https://clojars.org/workshub/leona) [![CircleCI](https://circleci.com/gh/WorksHub/leona.svg?style=svg)](https://circleci.com/gh/WorksHub/leona)
 
@@ -9,7 +10,7 @@ Leona can build Lacinia schema just by telling it the queries and mutations you 
 
 ## Quick Usage
 
-``` clojure
+```clojure
 (require '[leona.core :as leona])
 
 (let [schema (-> (leona/create)
@@ -18,7 +19,7 @@ Leona can build Lacinia schema just by telling it the queries and mutations you 
                  (leona/attach-field-resolver ::field-in-object field-resolver-fn)
                  (leona/attach-middleware middeware-fn)
                  (leona/compile))]
-  (leona/execute schema "query { object(id: 1001) { id, name, field_in_object }}")
+  (leona/execute schema "query { Object(Id: 1001) { Id, Name, FieldInObject }}")
 ```
 
 ## Examples
@@ -31,6 +32,7 @@ To add a query to the schema use `attach-query`:
 (-> (leona/create)
     (leona/attach-query ::query-spec ::object query-resolver-fn))
 ```
+
 `::query-spec` is a spec for the GraphQL query, `::object` is the spec for the returned data, and `query-resolver-fn` is the resolver function that will fetch and return the data.
 
 ### Mutations
@@ -41,6 +43,7 @@ Mutations are very similar to queries. To add a mutation to the schema use `atta
 (-> (leona/create)
     (leona/attach-mutation ::mutation-spec ::object mutator-fn))
 ```
+
 `::mutation-spec` is a spec for the GraphQL mutation, `::object` is the spec for the returned data, and `mutator-fn` is the function that will mutate the existing data and return the new, mutated data.
 
 ### Field Resolvers
@@ -53,11 +56,11 @@ To provide a resolver for a specific field, use `attach-field-resolver`:
     (leona/attach-field-resolver ::field-in-object field-resolver-fn)
 ```
 
-`::field-in-object` is a spec for the field in an existing object. **It must match a field already being inserted, in either a query or mutation. If the field isn't found amongst the objects in the schema then it won't be inserted.** `field-resolver-fn` is a resolver fn for that specific field. As is true of all field resolvers, it will be called *after* the root query/mutation resolver, so the `value` arg will already have data in it. The field resolver should add to this value.
+`::field-in-object` is a spec for the field in an existing object. **It must match a field already being inserted, in either a query or mutation. If the field isn't found amongst the objects in the schema then it won't be inserted.** `field-resolver-fn` is a resolver fn for that specific field. As is true of all field resolvers, it will be called _after_ the root query/mutation resolver, so the `value` arg will already have data in it. The field resolver should add to this value.
 
 ### Middleware
 
-It might be useful to add middleware *inside* the Lacinia executor e.g. you want to inspect a query/mutation prior to resolving **or** you want to inspect a value before it's passed back to Lacinia.
+It might be useful to add middleware _inside_ the Lacinia executor e.g. you want to inspect a query/mutation prior to resolving **or** you want to inspect a value before it's passed back to Lacinia.
 
 ```clojure
 (-> (leona/create)

--- a/src/leona/util.clj
+++ b/src/leona/util.clj
@@ -14,6 +14,38 @@
       (str/replace #"_QMARK_" "?")
       (str/replace #"_XMARK_" "!")))
 
+(defn- split-keep-delim 
+  [s re-delim]
+  (let [m (.matcher re-delim s)]
+    ((fn step [last-end]
+       (if (.find m)
+         (let [start (.start m)
+               end (.end m)
+               delim (.group m)
+               new-head (if (not= last-end start)
+                          [(.substring s last-end start) delim]
+                          [delim])]
+           (concat new-head (lazy-seq (step end))))
+         (if (not= last-end (.length s))
+           [(.substring s last-end)]
+           []))) 0)))
+
+(defn- PascalCase
+  [s]
+  (str/join ""
+    (map (fn [t] (if (str/starts-with? (str t) "_")
+                    (str t)
+                    (csk/->PascalCase t)))
+      (split-keep-delim s #"[__|___]"))))
+
+(defn- kebab-case
+  [s]
+  (str/join ""
+    (map (fn [t] (if (contains? (set "./") (str t))
+                    (str t)
+                    (csk/->kebab-case t)))
+      (split-keep-delim s #"[.|/]"))))
+
 (defn clj-name->gql-name
   [t]
   (-> t
@@ -28,9 +60,9 @@
             (-> t str (subs 1))
             (str t))]
     (-> t
-        (csk/->PascalCase)
         (str/replace #"\." "__")
         (str/replace #"\/" "___")
+        (PascalCase)
         (replace-punctuation)
         (keyword))))
 
@@ -41,5 +73,5 @@
       (str/replace #"___" "/")
       (str/replace #"__" ".")
       (replace-placeholders)
-      (csk/->kebab-case)
+      (kebab-case)
       (keyword)))

--- a/src/leona/util.clj
+++ b/src/leona/util.clj
@@ -18,7 +18,7 @@
   [t]
   (-> t
       (name)
-      (csk/->snake_case)
+      (csk/->PascalCase)
       (replace-punctuation)
       (keyword)))
 
@@ -28,7 +28,7 @@
             (-> t str (subs 1))
             (str t))]
     (-> t
-        (csk/->snake_case)
+        (csk/->PascalCase)
         (str/replace #"\." "__")
         (str/replace #"\/" "___")
         (replace-punctuation)

--- a/test/leona/core_test.clj
+++ b/test/leona/core_test.clj
@@ -52,26 +52,26 @@
    :operational? true})
 
 (deftest generate-query-test
-  (is (= {:droid
-          {:type :droid,
-           :args {:id {:type '(non-null Int)},
-                  (util/clj-name->qualified-gql-name ::test/appears-in) {:type '(list :episode)}}}}
+  (is (= {:Droid
+          {:type :Droid,
+           :args {:Id {:type '(non-null Int)},
+                  (util/clj-name->qualified-gql-name ::test/appears-in) {:type '(list :Episode)}}}}
          (-> (leona/create)
              (leona/attach-query ::test/droid-query ::test/droid droid-resolver)
              (leona/generate)
              :queries
-             (update :droid dissoc :resolve))))) ;; remove resolver because it gets wrapped
+             (update :Droid dissoc :resolve))))) ;; remove resolver because it gets wrapped
 
 (deftest generate-mutation-test
-  (is (= {:droid
-          {:type :droid,
-           :args {:id {:type '(non-null Int)},
-                  :primary_functions {:type '(list String)}}}}
+  (is (= {:Droid
+          {:type :Droid,
+           :args {:Id {:type '(non-null Int)},
+                  :PrimaryFunctions {:type '(list String)}}}}
          (-> (leona/create)
              (leona/attach-mutation ::test/droid-mutation ::test/droid droid-mutator)
              (leona/generate)
              :mutations
-             (update :droid dissoc :resolve)))))
+             (update :Droid dissoc :resolve)))))
 
 (deftest query-valid-test
   (let [appears-in-str (name (util/clj-name->qualified-gql-name ::test/appears-in))
@@ -79,26 +79,26 @@
                             (leona/attach-query ::test/droid-query ::test/droid droid-resolver)
                             (leona/compile))
         result (leona/execute compiled-schema
-                              (format "query { droid(id: 1001, %s: NEWHOPE) { name, operational_QMARK_, %s }}"
+                              (format "query { Droid(Id: 1001, %s: NEWHOPE) { Name, Operational_QMARK_, %s }}"
                                       appears-in-str
                                       appears-in-str))]
-    (is (= "R2D2" (get-in result [:data :droid :name])))
-    (is (= true (get-in result [:data :droid :operational_QMARK_])))
-    (is (= '(:NEWHOPE :EMPIRE :JEDI) (get-in result [:data :droid (keyword appears-in-str)])))))
+    (is (= "R2D2" (get-in result [:data :Droid :Name])))
+    (is (= true (get-in result [:data :Droid :Operational_QMARK_])))
+    (is (= '(:NEWHOPE :EMPIRE :JEDI) (get-in result [:data :Droid (keyword appears-in-str)])))))
 
 (deftest query-invalid-gql-test
   (let [compiled-schema (-> (leona/create)
                             (leona/attach-query ::test/droid-query ::test/droid droid-resolver)
                             (leona/compile))
-        result (leona/execute compiled-schema "query { droid(id: \"hello\") { name }}")] ;; id is NaN
+        result (leona/execute compiled-schema "query { Droid(Id: \"hello\") { Name }}")] ;; id is NaN
     (is (:errors result))
-    (is (= {:field :droid :argument :id :value "hello" :type-name :Int} (-> result :errors first :extensions)))))
+    (is (= {:field :Droid :argument :Id :value "hello" :type-name :Int} (-> result :errors first :extensions)))))
 
 (deftest query-invalid-query-spec-test
   (let [compiled-schema (-> (leona/create)
                             (leona/attach-query ::test/droid-query ::test/droid droid-resolver)
                             (leona/compile))
-        result (leona/execute compiled-schema "query { droid(id: 1002) { name }}")] ;; id is even
+        result (leona/execute compiled-schema "query { Droid(Id: 1002) { Name }}")] ;; id is even
     (is (:errors result))
     (is (= :invalid-query (-> result :errors first :extensions :key)))))
 
@@ -106,7 +106,7 @@
   (let [compiled-schema (-> (leona/create)
                             (leona/attach-query ::test/droid-query ::test/droid droid-resolver)
                             (leona/compile))
-        result (leona/execute compiled-schema "query { droid(id: 1003) { name }}")]
+        result (leona/execute compiled-schema "query { Droid(Id: 1003) { Name }}")]
     (is (:errors result))
     (is (= :invalid-query-result (-> result :errors first :extensions :key)))))
 
@@ -118,24 +118,24 @@
                             (leona/attach-mutation ::test/droid-mutation ::test/droid droid-mutator)
                             (leona/compile))
         result (leona/execute compiled-schema
-                              "mutation { droid(id: 1001, primary_functions: [\"beep\"]) { name, operational_QMARK_, primary_functions }}")]
-    (is (= "R2D2"   (get-in result [:data :droid :name])))
-    (is (= true     (get-in result [:data :droid :operational_QMARK_])))
-    (is (= ["beep"] (get-in result [:data :droid :primary_functions])))))
+                              "mutation { Droid(Id: 1001, PrimaryFunctions: [\"beep\"]) { Name, Operational_QMARK_, PrimaryFunctions }}")]
+    (is (= "R2D2"   (get-in result [:data :Droid :Name])))
+    (is (= true     (get-in result [:data :Droid :Operational_QMARK_])))
+    (is (= ["beep"] (get-in result [:data :Droid :PrimaryFunctions])))))
 
 (deftest mutation-invalid-gql-test
   (let [compiled-schema (-> (leona/create)
                             (leona/attach-mutation ::test/droid-mutation ::test/droid droid-mutator)
                             (leona/compile))
-        result (leona/execute compiled-schema "mutation { droid(id: \"hello\") { name }}")] ;; id is NaN
+        result (leona/execute compiled-schema "mutation { Droid(Id: \"hello\") { Name }}")] ;; id is NaN
     (is (:errors result))
-    (is (= {:field :droid :argument :id :value "hello" :type-name :Int} (-> result :errors first :extensions)))))
+    (is (= {:field :Droid :argument :Id :value "hello" :type-name :Int} (-> result :errors first :extensions)))))
 
 (deftest mutation-invalid-mutation-spec-test
   (let [compiled-schema (-> (leona/create)
                             (leona/attach-mutation ::test/droid-mutation ::test/droid droid-mutator)
                             (leona/compile))
-        result (leona/execute compiled-schema "mutation { droid(id: 1002) { name }}")] ;; id is even
+        result (leona/execute compiled-schema "mutation { Droid(Id: 1002) { Name }}")] ;; id is even
     (is (:errors result))
     (is (= :invalid-mutation (-> result :errors first :extensions :key)))))
 
@@ -143,7 +143,7 @@
   (let [compiled-schema (-> (leona/create)
                             (leona/attach-mutation ::test/droid-mutation ::test/droid droid-mutator)
                             (leona/compile))
-        result (leona/execute compiled-schema "mutation { droid(id: 1003) { name }}")]
+        result (leona/execute compiled-schema "mutation { Droid(Id: 1003) { Name }}")]
     (is (:errors result))
     (is (= :invalid-mutation-result (-> result :errors first :extensions :key)))))
 
@@ -162,8 +162,8 @@
         compiled-schema (-> (leona/create)
                             (leona/attach-query ::test-query ::test resolver)
                             (leona/compile))
-        result (leona/execute compiled-schema "query Test($input: input_input!) { test(input: $input) { num }}" {:input {:num 1, :nums [2 3]}} {})]
-    (is (= 6 (get-in result [:data :test :num])))))
+        result (leona/execute compiled-schema "query Test($Input: Input_input!) { Test(Input: $Input) { Num }}" {:Input {:Num 1, :Nums [2 3]}} {})]
+    (is (= 6 (get-in result [:data :Test :Num])))))
 
 ;;;;;
 
@@ -181,9 +181,9 @@
         compiled-schema (-> (leona/create)
                             (leona/attach-query ::test-query2 ::test resolver)
                             (leona/compile))
-        result (leona/execute compiled-schema "query Test($test_query: test_query_input!) { test(test_query: $test_query) { num }}"
-                              {:test_query {:input {:num 1, :nums [2 3]}}} {})]
-    (is (= 6 (get-in result [:data :test :num])))))
+        result (leona/execute compiled-schema "query Test($TestQuery: TestQuery_input!) { Test(TestQuery: $TestQuery) { Num }}"
+                              {:TestQuery {:Input {:Num 1, :Nums [2 3]}}} {})]
+    (is (= 6 (get-in result [:data :Test :Num])))))
 
 
 ;;;;;
@@ -202,8 +202,8 @@
         compiled-schema (-> (leona/create)
                             (leona/attach-query ::test-query ::test resolver)
                             (leona/compile))
-        result (leona/execute compiled-schema "query Test($inputs: [input_input!]!) { test(inputs: $inputs) { num }}" {:inputs [{:num 1, :nums [2 3]}]} {})]
-    (is (= 6 (get-in result [:data :test :num])))))
+        result (leona/execute compiled-schema "query Test($Inputs: [Input_input!]!) { Test(Inputs: $Inputs) { Num }}" {:Inputs [{:Num 1, :Nums [2 3]}]} {})]
+    (is (= 6 (get-in result [:data :Test :Num])))))
 
 
 
@@ -222,8 +222,8 @@
                    (leona/attach-query ::test/droid-query ::test/droid droid-resolver)
                    (leona/attach-middleware mw-fn2)
                    (leona/compile)
-                   (leona/execute "query { droid(id: 1001) { name }}"))]
-    (is (= "R2D2" (get-in result [:data :droid :name])))
+                   (leona/execute "query { Droid(Id: 1001) { Name }}"))]
+    (is (= "R2D2" (get-in result [:data :Droid :Name])))
     (is (= 25 @test-atom))))
 
 (deftest middleware-bail-test
@@ -233,9 +233,9 @@
                    (leona/attach-middleware mw-fn1)
                    (leona/attach-query ::test/droid-query ::test/droid droid-resolver)
                    (leona/compile)
-                   (leona/execute "query { droid(id: 1001) { name }}"))]
+                   (leona/execute "query { Droid(Id: 1001) { Name }}"))]
     (is (:errors result))
-    (is (= {:key :auth-failed, :arguments {:id 1001}} (-> result :errors first :extensions)))))
+    (is (= {:key :auth-failed, :arguments {:Id 1001}} (-> result :errors first :extensions)))))
 
 ;;;;;;;
 
@@ -249,9 +249,9 @@
                             (leona/attach-query ::test/droid-query ::test/droid droid-resolver)
                             (leona/attach-field-resolver ::test/owner human-resolver) ;; 'owner' is the field
                             (leona/compile))
-        result (leona/execute compiled-schema "query { droid(id: 1001) { name, operational_QMARK_, owner {id} }}")]
-    (is (= "R2D2" (get-in result [:data :droid :name])))
-    (is (= (:id human) (get-in result [:data :droid :owner :id])))))
+        result (leona/execute compiled-schema "query { Droid(Id: 1001) { Name, Operational_QMARK_, Owner {Id} }}")]
+    (is (= "R2D2" (get-in result [:data :Droid :Name])))
+    (is (= (:id human) (get-in result [:data :Droid :Owner :Id])))))
 
 
 (deftest field-resolver-included-test
@@ -261,9 +261,9 @@
   (s/def ::test-query (s/keys :opt-un [::a]))
   (let [r (-> (leona/create)
               (leona/attach-query ::test-query ::test droid-resolver)
-              (leona/attach-field-resolver ::b (constantly {:a 123}))
+              (leona/attach-field-resolver ::b (constantly {:A 123}))
               (leona/generate))]
-    (is (get-in r [:objects :test :fields :b :resolve]))))
+    (is (get-in r [:objects :Test :fields :B :resolve]))))
 
 (deftest field-resolver-coll-included-test
   (s/def ::a int?)
@@ -273,9 +273,9 @@
   (s/def ::test-query (s/keys :opt-un [::a]))
   (let [r (-> (leona/create)
               (leona/attach-query ::test-query ::test droid-resolver)
-              (leona/attach-field-resolver ::c (constantly {:a 123}))
+              (leona/attach-field-resolver ::c (constantly {:A 123}))
               (leona/generate))]
-    (is (get-in r [:objects :test :fields :c :resolve]))))
+    (is (get-in r [:objects :Test :fields :C :resolve]))))
 
 (deftest field-resolver-coll-included-in-ref-test
   (s/def ::a int?)
@@ -285,9 +285,9 @@
   (s/def ::test-query (s/keys :opt-un [::a]))
   (let [r (-> (leona/create)
               (leona/attach-query ::test-query ::test droid-resolver)
-              (leona/attach-field-resolver ::a (constantly {:a 123}))
+              (leona/attach-field-resolver ::a (constantly {:A 123}))
               (leona/generate))]
-    (is (get-in r [:objects :b :fields :a :resolve]))))
+    (is (get-in r [:objects :B :fields :A :resolve]))))
 
 ;;;;;;;
 

--- a/test/leona/real_schema_test.clj
+++ b/test/leona/real_schema_test.clj
@@ -122,8 +122,8 @@
 (deftest real-schema-test
   (let [r (schema/transform :wh/job)]
     (is r)
-    (is (= #{:location :company :salary :job} (set (keys (:objects r)))))
-    (is (= {:role_type {:values ["Intern" "Contract" "Full_time"]}} (:enums r)))))
+    (is (= #{:Location :Company :Salary :Job} (set (keys (:objects r)))))
+    (is (= {:RoleType {:values ["Intern" "Contract" "Full_time"]}} (:enums r)))))
 
 (deftest real-compile
   (s/def ::job-input (s/keys :req-un [:wh.job/id]))

--- a/test/leona/schema_test.clj
+++ b/test/leona/schema_test.clj
@@ -47,87 +47,87 @@
 (deftest schema-req-test
   (s/def ::a int?)
   (s/def ::test (s/keys :req [::a]))
-  (is (= {:objects {:test {:fields {(util/clj-name->qualified-gql-name ::a) {:type '(non-null Int)}}}}}
+  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a) {:type '(non-null Int)}}}}}
          (schema/transform ::test))))
 
 (deftest schema-req-with-nilable-test
   (s/def ::a (s/nilable int?))
   (s/def ::test (s/keys :req [::a]))
-  (is (= {:objects {:test {:fields {(util/clj-name->qualified-gql-name ::a) {:type '(non-null Int)}}}}}
+  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a) {:type '(non-null Int)}}}}}
          (schema/transform ::test))))
 
 (deftest schema-req-un-test
   (s/def ::a string?)
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type '(non-null String)}}}}}
+  (is (= {:objects {:Test {:fields {:A {:type '(non-null String)}}}}}
          (schema/transform ::test))))
 
 (deftest schema-req-un-with-nilable-test
   (s/def ::a (s/nilable string?))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type 'String}}}}}
+  (is (= {:objects {:Test {:fields {:A {:type 'String}}}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-test
   (s/def ::a int?)
   (s/def ::test (s/keys :opt [::a]))
-  (is (= {:objects {:test {:fields {(util/clj-name->qualified-gql-name ::a) {:type 'Int}}}}}
+  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a) {:type 'Int}}}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-with-nilable-test
   (s/def ::a (s/nilable int?))
   (s/def ::test (s/keys :opt [::a]))
-  (is (= {:objects {:test {:fields {(util/clj-name->qualified-gql-name ::a) {:type 'Int}}}}}
+  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a) {:type 'Int}}}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-un-test
   (s/def ::a string?)
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type 'String}}}}}
+  (is (= {:objects {:Test {:fields {:A {:type 'String}}}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-un-with-nilable-test
   (s/def ::a (s/nilable string?))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type 'String}}}}}
+  (is (= {:objects {:Test {:fields {:A {:type 'String}}}}}
          (schema/transform ::test))))
 
 (deftest schema-req-list-test
   (s/def ::a (s/coll-of string?))
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type '(non-null (list (non-null String)))}}}}}
+  (is (= {:objects {:Test {:fields {:A {:type '(non-null (list (non-null String)))}}}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-list-test
   (s/def ::a (s/coll-of string?))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type '(list String)}}}}}
+  (is (= {:objects {:Test {:fields {:A {:type '(list String)}}}}}
          (schema/transform ::test))))
 
 (deftest schema-req-enum-test
   (s/def ::a #{:foo :bar :baz})
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type '(non-null :a)}}}} :enums {:a {:values [:baz :bar :foo]}}}
+  (is (= {:objects {:Test {:fields {:A {:type '(non-null :A)}}}} :enums {:A {:values [:baz :bar :foo]}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-enum-test
   (s/def ::a #{:foo :bar :baz})
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type :a}}}} :enums {:a {:values [:baz :bar :foo]}}}
+  (is (= {:objects {:Test {:fields {:A {:type :A}}}} :enums {:A {:values [:baz :bar :foo]}}}
          (schema/transform ::test))))
 
 (deftest schema-req-enum-list-test
   (s/def ::a #{:foo :bar :baz})
   (s/def ::b (s/coll-of ::a))
   (s/def ::test (s/keys :req-un [::b]))
-  (is (= {:objects {:test {:fields {:b {:type '(non-null (list (non-null :a)))}}}} :enums {:a {:values [:baz :bar :foo]}}}
+  (is (= {:objects {:Test {:fields {:B {:type '(non-null (list (non-null :A)))}}}} :enums {:A {:values [:baz :bar :foo]}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-enum-list-test
   (s/def ::a #{:foo :bar :baz})
   (s/def ::b (s/coll-of ::a))
   (s/def ::test (s/keys :opt-un [::b]))
-  (is (= {:objects {:test {:fields {:b {:type '(list :a)}}}} :enums {:a {:values [:baz :bar :foo]}}}
+  (is (= {:objects {:Test {:fields {:B {:type '(list :A)}}}} :enums {:A {:values [:baz :bar :foo]}}}
          (schema/transform ::test))))
 
 (deftest schema-req-un-reference-test
@@ -136,10 +136,10 @@
   (s/def ::c string?)
   (s/def ::d (s/keys :req-un [::c]))
   (s/def ::test (s/keys :req-un [::b ::d]))
-  (is (= {:objects {:b {:fields {:a {:type '(non-null Int)}}}
-                    :d {:fields {:c {:type '(non-null String)}}}
-                    :test {:fields {:b {:type '(non-null :b)},
-                                    :d {:type '(non-null :d)}}}}}
+  (is (= {:objects {:B {:fields {:A {:type '(non-null Int)}}}
+                    :D {:fields {:C {:type '(non-null String)}}}
+                    :Test {:fields {:B {:type '(non-null :B)},
+                                    :D {:type '(non-null :D)}}}}}
          (schema/transform ::test))))
 
 (deftest schema-req-un-reference-opt-un-coll-test
@@ -147,8 +147,8 @@
   (s/def ::b (s/keys :req-un [::a]))
   (s/def ::c (s/coll-of ::b))
   (s/def ::test (s/keys :opt-un [::c]))
-  (is (= {:objects {:b {:fields {:a {:type '(non-null Int)}}}
-                    :test {:fields {:c {:type '(list :b)}}}}}
+  (is (= {:objects {:B {:fields {:A {:type '(non-null Int)}}}
+                    :Test {:fields {:C {:type '(list :B)}}}}}
          (schema/transform ::test))))
 
 (deftest schema-req-un-reference-req-un-coll-test
@@ -156,8 +156,8 @@
   (s/def ::b (s/keys :req-un [::a]))
   (s/def ::c (s/coll-of ::b))
   (s/def ::test (s/keys :req-un [::c]))
-  (is (= {:objects {:b {:fields {:a {:type '(non-null Int)}}}
-                    :test {:fields {:c {:type '(non-null (list (non-null :b)))}}}}}
+  (is (= {:objects {:B {:fields {:A {:type '(non-null Int)}}}
+                    :Test {:fields {:C {:type '(non-null (list (non-null :B)))}}}}}
          (schema/transform ::test))))
 
 (deftest schema-reference-name-req-req-test
@@ -165,8 +165,8 @@
   (s/def ::b (s/keys :req-un [::a]))
   (s/def ::c ::b)
   (s/def ::test (s/keys :req-un [::c]))
-  (is (= {:objects {:b {:fields {:a {:type '(non-null Int)}}}
-                    :test {:fields {:c {:type '(non-null :b)},}}}}
+  (is (= {:objects {:B {:fields {:A {:type '(non-null Int)}}}
+                    :Test {:fields {:C {:type '(non-null :B)},}}}}
          (schema/transform ::test))))
 
 (deftest schema-reference-name-opt-req-test
@@ -174,8 +174,8 @@
   (s/def ::b (s/keys :opt-un [::a]))
   (s/def ::c ::b)
   (s/def ::test (s/keys :req-un [::c]))
-  (is (= {:objects {:b {:fields {:a {:type 'Int}}}
-                    :test {:fields {:c {:type '(non-null :b)},}}}}
+  (is (= {:objects {:B {:fields {:A {:type 'Int}}}
+                    :Test {:fields {:C {:type '(non-null :B)},}}}}
          (schema/transform ::test))))
 
 (deftest schema-reference-name-opt-opt-test
@@ -183,8 +183,8 @@
   (s/def ::b (s/keys :opt-un [::a]))
   (s/def ::c ::b)
   (s/def ::test (s/keys :opt-un [::c]))
-  (is (= {:objects {:b {:fields {:a {:type 'Int}}}
-                    :test {:fields {:c {:type :b},}}}}
+  (is (= {:objects {:B {:fields {:A {:type 'Int}}}
+                    :Test {:fields {:C {:type :B},}}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-un-reference-test
@@ -193,10 +193,10 @@
   (s/def ::c string?)
   (s/def ::d (s/keys :opt-un [::c]))
   (s/def ::test (s/keys :opt-un [::b ::d]))
-  (is (= {:objects {:b {:fields {:a {:type 'Int}}}
-                    :d {:fields {:c {:type 'String}}}
-                    :test {:fields {:b {:type :b},
-                                    :d {:type :d}}}}}
+  (is (= {:objects {:B {:fields {:A {:type 'Int}}}
+                    :D {:fields {:C {:type 'String}}}
+                    :Test {:fields {:B {:type :B},
+                                    :D {:type :D}}}}}
          (schema/transform ::test))))
 
 (deftest schema-merge-test
@@ -205,15 +205,15 @@
   (s/def ::c string?)
   (s/def ::d (s/keys :opt-un [::c]))
   (s/def ::test (s/merge ::b ::d))
-  (is (= {:objects {:test {:fields {:a {:type 'Int},
-                                    :c {:type 'String}}}}}
+  (is (= {:objects {:Test {:fields {:A {:type 'Int},
+                                    :C {:type 'String}}}}}
          (schema/transform ::test))))
 
 (deftest schema-and-test
   "If we recognise a predicate we use that"
   (s/def ::a (s/and int? odd?))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type 'Int}}}}}
+  (is (= {:objects {:Test {:fields {:A {:type 'Int}}}}}
          (schema/transform ::test))))
 
 (deftest schema-and-test-fail
@@ -226,7 +226,7 @@
   "If we recognise a predicate we use that"
   (s/def ::a (s/or :int int? :odd odd?))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type 'Int}}}}}
+  (is (= {:objects {:Test {:fields {:A {:type 'Int}}}}}
          (schema/transform ::test))))
 
 (deftest schema-or-test-fail
@@ -252,22 +252,22 @@
 
 (def result
   {:objects
-   {:human
+   {:Human
     {:fields
-     {:home_planet {:type '(non-null String)},
-      :id {:type '(non-null Int)},
-      :name {:type '(non-null String)},
-      :appears_in {:type '(non-null (list (non-null :episode)))},
-      :episode {:type :episode}}},
-    :droid
+     {:HomePlanet {:type '(non-null String)},
+      :Id {:type '(non-null Int)},
+      :Name {:type '(non-null String)},
+      :AppearsIn {:type '(non-null (list (non-null :Episode)))},
+      :Episode {:type :Episode}}},
+    :Droid
     {:fields
-     {:primary_functions {:type '(non-null (list (non-null String)))},
-      :id {:type '(non-null Int)},
-      :name {:type '(non-null String)},
-      :owner      {:type :human},
-      (util/clj-name->qualified-gql-name ::test/appears-in) {:type '(non-null (list (non-null :episode)))},
-      :operational_QMARK_ {:type 'Boolean}}}},
-   :enums {:episode {:values [:EMPIRE :NEWHOPE :JEDI]}}})
+     {:PrimaryFunctions {:type '(non-null (list (non-null String)))},
+      :Id {:type '(non-null Int)},
+      :Name {:type '(non-null String)},
+      :Owner      {:type :Human},
+      (util/clj-name->qualified-gql-name ::test/appears-in) {:type '(non-null (list (non-null :Episode)))},
+      :Operational_QMARK_ {:type 'Boolean}}}},
+   :enums {:Episode {:values [:EMPIRE :NEWHOPE :JEDI]}}})
 
 (deftest comprehensive-schema-test
   (is (= result
@@ -279,23 +279,23 @@
 (deftest schema-description-test
   (s/def ::a (st/spec int? {:description "FooBarBaz"}))
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type '(non-null Int) :description "FooBarBaz"}}}}}
+  (is (= {:objects {:Test {:fields {:A {:type '(non-null Int) :description "FooBarBaz"}}}}}
          (schema/transform ::test))))
 
 (deftest schema-type-test
   (s/def ::a (st/spec int? {:type 'Boolean}))
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type 'Boolean}}}}}
+  (is (= {:objects {:Test {:fields {:A {:type 'Boolean}}}}}
          (schema/transform ::test))))
 
 (deftest schema-type-enum-test
   (s/def ::a (st/spec int? {:type '(enum :foo)}))
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type :foo}}}}}
+  (is (= {:objects {:Test {:fields {:A {:type :foo}}}}}
          (schema/transform ::test))))
 
 (deftest schema-type-kw-ignored-test
   (s/def ::a (st/spec int? {:type :foo}))
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type '(non-null Int)}}}}}
+  (is (= {:objects {:Test {:fields {:A {:type '(non-null Int)}}}}}
          (schema/transform ::test))))

--- a/test/leona/util_test.clj
+++ b/test/leona/util_test.clj
@@ -13,10 +13,11 @@
   (is (= "hello!" (util/replace-placeholders "hello_XMARK_"))))
 
 (deftest clj-name->gql-name-test
-  (is (= :hello (util/clj-name->gql-name :hello)))
-  (is (= :hello (util/clj-name->gql-name ::hello)))
-  (is (= :hello_QMARK_ (util/clj-name->gql-name ::hello?)))
-  (is (= :hello_QMARK_ (util/clj-name->gql-name :leona.util-test/hello?))))
+  (is (= :Hello (util/clj-name->gql-name :hello)))
+  (is (= :Hello (util/clj-name->gql-name ::hello)))
+  (is (= :HelloName (util/clj-name->gql-name ::hello_name)))
+  (is (= :Hello_QMARK_ (util/clj-name->gql-name ::hello?)))
+  (is (= :Hello_QMARK_ (util/clj-name->gql-name :leona.util-test/hello?))))
 
 (deftest clj-name->qualified-gql-name-test
   (is (= :hello (util/clj-name->qualified-gql-name :hello)))

--- a/test/leona/util_test.clj
+++ b/test/leona/util_test.clj
@@ -20,13 +20,13 @@
   (is (= :Hello_QMARK_ (util/clj-name->gql-name :leona.util-test/hello?))))
 
 (deftest clj-name->qualified-gql-name-test
-  (is (= :hello (util/clj-name->qualified-gql-name :hello)))
-  (is (= :leona__util_test___hello (util/clj-name->qualified-gql-name ::hello)))
-  (is (= :leona__util_test___hello_QMARK_ (util/clj-name->qualified-gql-name ::hello?)))
-  (is (= :leona__util_test___hello_QMARK_ (util/clj-name->qualified-gql-name :leona.util-test/hello?))))
+  (is (= :Hello (util/clj-name->qualified-gql-name :hello)))
+  (is (= :Leona__UtilTest___Hello (util/clj-name->qualified-gql-name ::hello)))
+  (is (= :Leona__UtilTest___Hello_QMARK_ (util/clj-name->qualified-gql-name ::hello?)))
+  (is (= :Leona__UtilTest___Hello_QMARK_ (util/clj-name->qualified-gql-name :leona.util-test/hello?))))
 
-(deftest clj-name->qualified-gql-name-test
-  (is (= :hello (util/gql-name->clj-name :hello)))
-  (is (= (util/gql-name->clj-name :leona__util_test___hello)))
-  (is (= ::hello? (util/gql-name->clj-name :leona__util_test___hello_QMARK_)))
-  (is (= :leona.util-test/hello? (util/gql-name->clj-name :leona__util_test___hello_QMARK_))))
+(deftest qualified-gql-name-test->clj-name
+  (is (= :hello (util/gql-name->clj-name :Hello)))
+  (is (= ::hello (util/gql-name->clj-name :Leona__UtilTest___Hello)))
+  (is (= ::hello? (util/gql-name->clj-name :Leona__UtilTest___Hello_QMARK_)))
+  (is (= :leona.util-test/hello? (util/gql-name->clj-name :Leona__UtilTest___Hello_QMARK_))))


### PR DESCRIPTION
Fixes issue #17 

The fix broke most of the tests which required changing, but they all work now. I also may have done this entirely the wrong way, if so, well at least I learned more about clojure in the process...

My solution to getting the name conversion functions to work as intended feels a bit hacky to me, but I couldn't really think of another way to do it. Specifically, the `camel-snake-kebab` library couldn't convert the cases correctly for the namespaces due to the dots and slashes.

As an example:
`:leona.util-test/hello` would convert to `:Leona__utilTest___hello`
Rather than `:Leona__UtilTest___Hello` as would be expected.
The opposite conversion was also not working, it would convert to `:leona.-util-test/-hello`

So, as a work around I added a couple utility functions that wrap the calls to the `csk` library so the correct separators would be preserved while converting the case.

Also fixed an issue with a misnamed test. In the tests for the util functions, one of the tests had the same name as one of the other tests and as such neither of them were running.