### PR TITLE
Add type aliasing to objects, enums and queries/mutations

### DIFF
--- a/src/leona/core.clj
+++ b/src/leona/core.clj
@@ -187,6 +187,12 @@
     (reduce (partial merge-with merge) generated schemas)
     generated))
 
+(defn attach-type-alias
+  "Attach an alias to a spec that's a type. All type instances of that spec name will be replaced with the alias. This can be used to avoid conflicts."
+  [m spec alias]
+  {:pre [(s/valid? ::pre-compiled-data m)]}
+  (assoc-in m [:type-aliases spec] alias))
+
 ;;;;;
 
 (defn transform-input-object-key

--- a/test/leona/core_test.clj
+++ b/test/leona/core_test.clj
@@ -26,7 +26,7 @@
                                       :mutation-spec ::test/droid-mutation}}
             :field-resolvers {::test/owner {:resolver human-resolver}}
             :schemas []
-            :aliases {}}
+            :type-aliases {}}
            (-> (leona/create)
                (leona/attach-query ::test/droid-query ::test/droid droid-resolver)
                (leona/attach-mutation ::test/droid-mutation ::test/droid droid-mutator)

--- a/test/leona/core_test.clj
+++ b/test/leona/core_test.clj
@@ -25,7 +25,8 @@
             :mutations {::test/droid {:resolver droid-mutator
                                       :mutation-spec ::test/droid-mutation}}
             :field-resolvers {::test/owner {:resolver human-resolver}}
-            :schemas []}
+            :schemas []
+            :aliases {}}
            (-> (leona/create)
                (leona/attach-query ::test/droid-query ::test/droid droid-resolver)
                (leona/attach-mutation ::test/droid-mutation ::test/droid droid-mutator)
@@ -316,3 +317,58 @@
               (leona/attach-schema schema)
               (leona/compile))]
     (is (= identity (get-in r [:generated :queries :alice :resolve])))))
+
+
+;;;;;;;
+
+(deftest add-alias-basic-test
+  (s/def :foo/status #{:a :b :c})
+  (s/def ::my-foo-object (s/keys :req-un [:foo/status]))
+  (s/def ::my-query-var int?)
+  (s/def ::foo-query-args (s/keys :req-un [::my-query-var]))
+
+  (let [r (-> (leona/create)
+              (leona/attach-query ::foo-query-args ::my-foo-object (constantly nil))
+              (leona/attach-type-alias :foo/status :foo-status)
+              (leona/generate))]
+    (is (= '(non-null :foo_status) (get-in r [:objects :my_foo_object :fields :status :type])))
+    (is (= #{:a :b :c} (set (get-in r [:enums :foo_status :values]))))))
+
+(deftest add-alias-medium-test
+  (s/def :foo/status #{:a :b :c})
+  (s/def :bar/status #{:d :e :f})
+  (s/def ::my-foo-object (s/keys :req-un [:foo/status]))
+  (s/def ::my-bar-object (s/keys :req-un [:bar/status]))
+  (s/def ::my-query-var int?)
+  (s/def ::query-args (s/keys :req-un [::my-query-var]))
+  (let [r (-> (leona/create)
+              (leona/attach-query ::query-args ::my-foo-object (constantly {:status :a}))
+              (leona/attach-query ::query-args ::my-bar-object (constantly {:status :d}))
+              (leona/attach-type-alias :foo/status :foo-status)
+              (leona/compile))]
+    (is (= '(non-null :foo_status) (get-in r [:generated :objects :my_foo_object :fields :status :type])))
+    (is (= '(non-null :status) (get-in r [:generated :objects :my_bar_object :fields :status :type])))
+    (is (= #{:a :b :c} (set (get-in r [:generated :enums :foo_status :values]))))
+    (is (= #{:d :e :f} (set (get-in r [:generated :enums :status :values]))))
+    (let [r (leona/execute r "query { my_foo_object(my_query_var: 1001) { status }}")]
+      (is (= :a (get-in r [:data :my_foo_object :status]))))))
+
+(deftest add-alias-in-query-test
+  (s/def ::value int?)
+  (s/def :foo/selector #{:foo :bar})
+  (s/def :bar/selector #{:baz :qux})
+  (s/def ::my-foo-object (s/keys :req-un [::value :foo/selector]))
+  (s/def ::my-bar-object (s/keys :req-un [::value :bar/selector]))
+  (s/def ::foo-query-args (s/keys :req-un [:foo/selector]))
+  (s/def ::bar-query-args (s/keys :req-un [:bar/selector]))
+  (let [r (-> (leona/create)
+              (leona/attach-query ::foo-query-args ::my-foo-object (constantly {:value 123 :selector :foo}))
+              (leona/attach-query ::bar-query-args ::my-bar-object (constantly {:value 456 :selector :qux}))
+              (leona/attach-type-alias :foo/selector :foo-status)
+              (leona/compile))]
+    (is (= '(non-null :foo_status) (get-in r [:generated :objects :my_foo_object :fields :selector :type])))
+    (is (= '(non-null :foo_status) (get-in r [:generated :queries :my_foo_object :args :selector :type])))
+    (is (= #{:foo :bar} (set (get-in r [:generated :enums :foo_status :values]))))
+    (is (= #{:baz :qux} (set (get-in r [:generated :enums :selector :values]))))
+    (let [r (leona/execute r "query { my_foo_object(selector: foo) { value }}")]
+      (is (= 123 (get-in r [:data :my_foo_object :value]))))))

--- a/test/leona/schema_test.clj
+++ b/test/leona/schema_test.clj
@@ -299,3 +299,20 @@
   (s/def ::test (s/keys :req-un [::a]))
   (is (= {:objects {:test {:fields {:a {:type '(non-null Int)}}}}}
          (schema/transform ::test))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(deftest type-alias-enum-test
+  (s/def :foo/status #{:a :b :c})
+  (s/def ::test (s/keys :req-un [:foo/status]))
+  (is (= {:objects {:test {:fields {:status {:type '(non-null :foo_status)}}}}
+          :enums {:foo_status {:values [:c :b :a]}}}
+         (schema/transform ::test {:type-aliases {:foo/status :foo-status}}))))
+
+(deftest type-alias-object-test
+  (s/def ::foo int?)
+  (s/def ::bar (s/keys :opt-un [::foo]))
+  (s/def ::test (s/keys :req-un [::bar]))
+  (is (= {:objects {:test {:fields {:bar {:type '(non-null :baz)}}}
+                    :baz {:fields {:foo {:type 'Int}}}}}
+         (schema/transform ::test {:type-aliases {::bar :baz}}))))


### PR DESCRIPTION
Addresses https://github.com/WorksHub/leona/issues/21

In this PR we add a new function `attach-type-alias`. This function takes a spec and an alias:

```clojure
(-> (leona/create)
    (leona/attach-type-alias ::foo/bar :foo-bar)
```

This aliases is applied at the point of spec transformation and replaces any _type references_ of the spec with the specified alias. It *does not* change field names. 

In the above example, if `::foo/bar` is a set (enum) or `s/keys` (object) spec then anywhere - including queries and mutations - that references it as a _type_ (i.e. `{:type (non-null :bar)}` in the schema, after the name has been extracted), it will be replaced with the alias (i.e. `{:type (non-null :foo-bar)}`). Any objects using this spec as a _field_ (i.e. `(s/def ::foo (s/keys :req-un [::foo/bar])`) will still use the un-aliased field name (`bar` in this case)
