### PR TITLE
Add custom scalars

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,21 @@ In order to use the middleware you'll need to use leona's `execute` fn:
 
 `compiled` is the output of `(leona/compile)` and `execute-string` is a GraphQL query/mutation/etc.
 
+### Custom Scalars
+
+[Custom scalars](https://lacinia.readthedocs.io/en/latest/custom-scalars.html) are also supported.
+
+``` clojure
+(-> (leona/create)
+    ...
+    (leona/attach-custom-scalar ::date {:parse     #(tf/parse (tf/formatters :date-time) %)
+                                        :serialize #(tf/unparse (tf/formatters :date-time) %)}))
+```
+
+Anywhere the `::date` spec is referenced by an object, query or mutation, the `parse` and `serialize` fns will be used to transform the data. Be aware, however; whilst Leona will still perform its own internal spec validation, Lacinia will not perform validation for over-the-wire values. It's therefore important that your `parse` fn can handle incorrect data (unlike the one in the example!) and will still return something valid to Leona.
+
+
+
 ### Other
 
 If your spec cannot be inferred (automatically converted into an accurate schema) you can always override the inferred type by using the `spec` function from `spec-tools`:

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,8 @@
                  [com.walmartlabs/lacinia "0.31.0"]
                  [metosin/spec-tools "0.8.0"]
                  [camel-snake-kebab "0.4.0"]]
-  :profiles {:dev {:dependencies [[org.clojure/test.check "0.10.0-alpha3"]]}}
+  :profiles {:dev {:dependencies [[org.clojure/test.check "0.10.0-alpha3"]
+                                  [clj-time "0.14.2"]]}}
   :repositories [["releases" {:url "https://clojars.org/repo"
                               :creds :gpg}]
                  ["snapshots" {:url "https://clojars.org/repo"

--- a/src/leona/util.clj
+++ b/src/leona/util.clj
@@ -43,3 +43,15 @@
       (replace-placeholders)
       (csk/->kebab-case)
       (keyword)))
+
+;; https://stackoverflow.com/a/26059795
+(defn contains-in?
+  [m ks]
+  (not= ::absent (get-in m ks ::absent)))
+
+(defn update-in*
+  "Only calls `update-in` if key exists"
+  [m ks f & args]
+  (if (contains-in? m ks)
+    (apply (partial update-in m ks f) args)
+    m))

--- a/src/leona/util.clj
+++ b/src/leona/util.clj
@@ -43,15 +43,3 @@
       (replace-placeholders)
       (csk/->kebab-case)
       (keyword)))
-
-;; https://stackoverflow.com/a/26059795
-(defn contains-in?
-  [m ks]
-  (not= ::absent (get-in m ks ::absent)))
-
-(defn update-in*
-  "Only calls `update-in` if key exists"
-  [m ks f & args]
-  (if (contains-in? m ks)
-    (apply (partial update-in m ks f) args)
-    m))

--- a/test/leona/core_test.clj
+++ b/test/leona/core_test.clj
@@ -26,7 +26,8 @@
                                       :mutation-spec ::test/droid-mutation}}
             :field-resolvers {::test/owner {:resolver human-resolver}}
             :schemas []
-            :type-aliases {}}
+            :type-aliases {}
+            :custom-scalars {}}
            (-> (leona/create)
                (leona/attach-query ::test/droid-query ::test/droid droid-resolver)
                (leona/attach-mutation ::test/droid-mutation ::test/droid droid-mutator)

--- a/test/leona/core_test.clj
+++ b/test/leona/core_test.clj
@@ -254,7 +254,6 @@
     (is (= "R2D2" (get-in result [:data :droid :name])))
     (is (= (:id human) (get-in result [:data :droid :owner :id])))))
 
-
 (deftest field-resolver-included-test
   (s/def ::a int?)
   (s/def ::b (s/keys :req-un [::a]))

--- a/test/leona/custom_scalar_test.clj
+++ b/test/leona/custom_scalar_test.clj
@@ -5,7 +5,23 @@
              [clojure.spec.alpha :as s]
              [clojure.test :refer :all]
              [leona.core :as leona]
+             [leona.schema :as leona-schema]
              [spec-tools.core :as st]))
+
+(deftest custom-scalars-are-preserved-at-schema-time
+  (s/def ::date tt/date-time?)
+  (s/def ::num int?)
+  (s/def ::bool boolean?)
+  (s/def ::result-1 (s/keys :req-un [::date]))
+  (s/def ::result-2 (s/keys :opt-un [::num]))
+  (s/def ::result-3 (s/keys :req-un [::bool]))
+  (let [r (leona-schema/combine-with-opts
+            {:custom-scalars {::date {:parse identity :serialize identity}
+                              ::num  {:parse identity :serialize identity}}}
+            ::result-1
+            ::result-2
+            ::result-3)]
+    (is (= r {:objects {:result_1 {:fields {:date {:type '(non-null :date)}}}, :result_2 {:fields {:num {:type :num}}}, :result_3 {:fields {:bool {:type '(non-null Boolean)}}}}}))))
 
 (deftest custom-scalar-test
   (s/def ::date (st/spec tt/date-time? {:type 'String}))
@@ -17,42 +33,35 @@
                    (let [{:keys [date]} query]
                      {:result {:date (t/plus date (t/years 1))}}))
         compiled-schema (-> (leona/create)
-                            (leona/attach-query ::test-query ::test resolver)
-                            (leona/attach-custom-scalar ::date {:parse #(tf/parse (tf/formatters :date-time) %)
-                                                                :serialize #(tf/unparse (tf/formatters :date-time) %)})
-                            (leona/compile))
+                          (leona/attach-query ::test-query ::test resolver)
+                          (leona/attach-custom-scalar ::date {:parse #(tf/parse (tf/formatters :date-time) %)
+                                                              :serialize #(tf/unparse (tf/formatters :date-time) %)})
+                          (leona/compile))
         result (leona/execute compiled-schema "query Test($date: date!) { test(date: $date) { result {date} }}" {:date (str now-date)} {})]
-    (is (= :date (get-in compiled-schema [:generated :queries :test :args :date :type])))
-    (is (= :date (get-in compiled-schema [:generated :objects :result :fields :date :type])))
+    (is (= '(non-null :date) (get-in compiled-schema [:generated :queries :test :args :date :type])))
+    (is (= '(non-null :date) (get-in compiled-schema [:generated :objects :result :fields :date :type])))
     (let [d (get-in result [:data :test :result :date])]
       (is (= (str (t/plus now-date (t/years 1))) d)))))
 
-;; This kind of post-generation replacement will not work for places where the spec is exploded
-;; Basically, unless we are replacing an object, we've lost of the spec by the time we get to this stage.
-;; What we should do instead:
-;; Schema generation has custom scalars info passed in and when we encounter such a spec that is flagged as a CS
-;; you literally leave it alone and do not replace it with the form. We don't even want to give it a special notation lest
-;; we fuck with people's queries like we have with input objects.
-
-#_(deftest custom-scalar-test--collection
-    (s/def ::date (st/spec tt/date-time? {:type 'String}))
-    (s/def ::dates (s/coll-of ::date))
-    (s/def ::result (s/keys :req-un [::dates]))
-    (s/def ::test (s/keys :req-un [::result]))
-    (s/def ::test-query (s/keys :req-un [::date]))
-    (let [now-date (t/now)
-          resolver (fn [ctx query value]
-                     (let [{:keys [date]} query]
-                       {:result {:dates [(t/plus date (t/years 1))
-                                         (t/minus date (t/years 1))]}}))
-          compiled-schema (-> (leona/create)
-                              (leona/attach-query ::test-query ::test resolver)
-                              (leona/attach-custom-scalar ::date {:parse #(tf/parse (tf/formatters :date-time) %)
-                                                                  :serialize #(tf/unparse (tf/formatters :date-time) %)})
-                              (leona/compile))
-          result (leona/execute compiled-schema "query Test($date: date!) { test(date: $date) { result {dates} }}" {:date (str now-date)} {})]
-      (is (= :date (get-in compiled-schema [:generated :queries :test :args :date :type])))
-      (is (= :date (get-in compiled-schema [:generated :objects :result :fields :date :type])))
-      (let [d (get-in result [:data :test :result :dates])]
-        (is (= (str (t/plus now-date (t/years 1))) (first d)))
-        (is (= (str (t/minus now-date (t/years 1))) (second d))))))
+(deftest custom-scalar-test--collection
+  (s/def ::date (st/spec tt/date-time? {:type 'String}))
+  (s/def ::dates (s/coll-of ::date))
+  (s/def ::result (s/keys :req-un [::dates]))
+  (s/def ::test (s/keys :req-un [::result]))
+  (s/def ::test-query (s/keys :req-un [::date]))
+  (let [now-date (t/now)
+        resolver (fn [ctx query value]
+                   (let [{:keys [date]} query]
+                     {:result {:dates [(t/plus date (t/years 1))
+                                       (t/minus date (t/years 1))]}}))
+        compiled-schema (-> (leona/create)
+                          (leona/attach-query ::test-query ::test resolver)
+                          (leona/attach-custom-scalar ::date {:parse #(tf/parse (tf/formatters :date-time) %)
+                                                              :serialize #(tf/unparse (tf/formatters :date-time) %)})
+                          (leona/compile))
+        result (leona/execute compiled-schema "query Test($date: date!) { test(date: $date) { result {dates} }}" {:date (str now-date)} {})]
+    (is (= '(non-null :date) (get-in compiled-schema [:generated :queries :test :args :date :type])))
+    (is (= '(non-null (list (non-null :date))) (get-in compiled-schema [:generated :objects :result :fields :dates :type])))
+    (let [d (get-in result [:data :test :result :dates])]
+      (is (= (str (t/plus now-date (t/years 1))) (first d)))
+      (is (= (str (t/minus now-date (t/years 1))) (second d))))))

--- a/test/leona/custom_scalar_test.clj
+++ b/test/leona/custom_scalar_test.clj
@@ -1,0 +1,58 @@
+(ns leona.custom-scalar-test
+  (:require  [clj-time.core :as t]
+             [clj-time.format :as tf]
+             [clj-time.types :as tt]
+             [clojure.spec.alpha :as s]
+             [clojure.test :refer :all]
+             [leona.core :as leona]
+             [spec-tools.core :as st]))
+
+(deftest custom-scalar-test
+  (s/def ::date (st/spec tt/date-time? {:type 'String}))
+  (s/def ::result (s/keys :req-un [::date]))
+  (s/def ::test (s/keys :req-un [::result]))
+  (s/def ::test-query (s/keys :req-un [::date]))
+  (let [now-date (t/now)
+        resolver (fn [ctx query value]
+                   (let [{:keys [date]} query]
+                     {:result {:date (t/plus date (t/years 1))}}))
+        compiled-schema (-> (leona/create)
+                            (leona/attach-query ::test-query ::test resolver)
+                            (leona/attach-custom-scalar ::date {:parse #(tf/parse (tf/formatters :date-time) %)
+                                                                :serialize #(tf/unparse (tf/formatters :date-time) %)})
+                            (leona/compile))
+        result (leona/execute compiled-schema "query Test($date: date!) { test(date: $date) { result {date} }}" {:date (str now-date)} {})]
+    (is (= :date (get-in compiled-schema [:generated :queries :test :args :date :type])))
+    (is (= :date (get-in compiled-schema [:generated :objects :result :fields :date :type])))
+    (let [d (get-in result [:data :test :result :date])]
+      (is (= (str (t/plus now-date (t/years 1))) d)))))
+
+;; This kind of post-generation replacement will not work for places where the spec is exploded
+;; Basically, unless we are replacing an object, we've lost of the spec by the time we get to this stage.
+;; What we should do instead:
+;; Schema generation has custom scalars info passed in and when we encounter such a spec that is flagged as a CS
+;; you literally leave it alone and do not replace it with the form. We don't even want to give it a special notation lest
+;; we fuck with people's queries like we have with input objects.
+
+#_(deftest custom-scalar-test--collection
+    (s/def ::date (st/spec tt/date-time? {:type 'String}))
+    (s/def ::dates (s/coll-of ::date))
+    (s/def ::result (s/keys :req-un [::dates]))
+    (s/def ::test (s/keys :req-un [::result]))
+    (s/def ::test-query (s/keys :req-un [::date]))
+    (let [now-date (t/now)
+          resolver (fn [ctx query value]
+                     (let [{:keys [date]} query]
+                       {:result {:dates [(t/plus date (t/years 1))
+                                         (t/minus date (t/years 1))]}}))
+          compiled-schema (-> (leona/create)
+                              (leona/attach-query ::test-query ::test resolver)
+                              (leona/attach-custom-scalar ::date {:parse #(tf/parse (tf/formatters :date-time) %)
+                                                                  :serialize #(tf/unparse (tf/formatters :date-time) %)})
+                              (leona/compile))
+          result (leona/execute compiled-schema "query Test($date: date!) { test(date: $date) { result {dates} }}" {:date (str now-date)} {})]
+      (is (= :date (get-in compiled-schema [:generated :queries :test :args :date :type])))
+      (is (= :date (get-in compiled-schema [:generated :objects :result :fields :date :type])))
+      (let [d (get-in result [:data :test :result :dates])]
+        (is (= (str (t/plus now-date (t/years 1))) (first d)))
+        (is (= (str (t/minus now-date (t/years 1))) (second d))))))


### PR DESCRIPTION
In this PR we add support for custom scalars. In all honesty, this isn't 100% battle tested but we have a feature coming up in our app that will test this, so there could be more changes to come.

The approach is slightly delicate; we effectively 'preserve' the spec names whenever we encounter them during the schema generation phase. The core `generate` process then adds the scalar names and fns into the right location. Without both separate steps, it would fail. The 'preservation' mechanism could even be used, at some point, to replace object reference fixing which happens at the end of the schema generation.