### PR TITLE
Add a new type override symbol specifically for custom scalars

### DIFF
--- a/src/leona/schema.clj
+++ b/src/leona/schema.clj
@@ -10,6 +10,11 @@
             [spec-tools.parse :as parse]
             [spec-tools.visitor :as visitor]))
 
+
+(def valid-type-override-syms
+  "These symbols can be used to wrap types when using `st/spec`, e.g. `(st/spec my-date-pred? {:type '(custom :date)})`. They only exist separately to provide semantic information - it's not asserted anywhere that the types they reference ever exist anywhere so USE WITH CAUTION."
+  #{'enum 'custom})
+
 (defn- only-entry? [key a-map] (= [key] (keys a-map)))
 
 (defn- spec-dispatch [dispatch _ _ _] dispatch)
@@ -351,7 +356,7 @@
   [t]
   (if t
     (let [flat (flatten [t])]
-      (if (= (first flat) 'enum)
+      (if (valid-type-override-syms (first flat))
         (keyword? (second flat))
         (s/valid? ::replacement-types flat)))
     false))
@@ -363,8 +368,8 @@
         un-children (impl/unwrap children)]
     (merge
       (if (valid-replacement-type? replacement-type)
-        (let [replacement-type' (if (and (seq? replacement-type) ;; extract enum if we have one
-                                         (= (first replacement-type) 'enum))
+        (let [replacement-type' (if (and (seq? replacement-type) ;; extract valid type override fn if we have one
+                                         (valid-type-override-syms (first replacement-type)))
                                   (second replacement-type)
                                   replacement-type)]
           (if (map? un-children)

--- a/test/leona/custom_scalar_test.clj
+++ b/test/leona/custom_scalar_test.clj
@@ -44,6 +44,27 @@
     (let [d (get-in result [:data :test :result :date])]
       (is (= (str (t/plus now-date (t/years 1))) d)))))
 
+(deftest custom-scalar-test--indirect
+  (s/def ::date (st/spec tt/date-time? {:type '(custom :date)})) ;; <-- Notice the use of this super special secret type symbol
+  (s/def ::indirect-date ::date)
+  (s/def ::result (s/keys :req-un [::indirect-date]))
+  (s/def ::test (s/keys :req-un [::result]))
+  (s/def ::test-query (s/keys :req-un [::date]))
+  (let [now-date (t/now)
+        resolver (fn [ctx query value]
+                   (let [{:keys [date]} query]
+                     {:result {:indirect-date (t/plus date (t/years 1))}}))
+        compiled-schema (-> (leona/create)
+                            (leona/attach-query ::test-query ::test resolver)
+                            (leona/attach-custom-scalar ::date {:parse #(tf/parse (tf/formatters :date-time) %)
+                                                                :serialize #(tf/unparse (tf/formatters :date-time) %)})
+                            (leona/compile))
+        result (leona/execute compiled-schema "query Test($date: date!) { test(date: $date) { result {indirect_date} }}" {:date (str now-date)} {})]
+    (is (= '(non-null :date) (get-in compiled-schema [:generated :queries :test :args :date :type])))
+    (is (= :date (get-in compiled-schema [:generated :objects :result :fields :indirect_date :type])))
+    (let [d (get-in result [:data :test :result :indirect_date])]
+      (is (= (str (t/plus now-date (t/years 1))) d)))))
+
 (deftest custom-scalar-test--collection
   (s/def ::date tt/date-time?)
   (s/def ::dates (s/coll-of ::date))


### PR DESCRIPTION
This PR introduces a new 'type override symbol'. What does that mean?

Right now, you can do something like this:

```clojure
;; my-pred will use `String as its type
(st/spec my-pred {:type 'String})

;; my-pred will use :foo as its type - if :foo doesn't exist, compilation will fail, 
;; but you are indicating you expect there to be an enum with this type
(st/spec my-pred {:type '(enum :foo})
```
Now you can also do

```clojure
;; my-pred will use :foo as its type - if :foo doesn't exist, compilation will fail,
;; but you are indicating you expect there to be a custom scalar with this type
(st/spec my-pred {:type '(custom :foo})
```

There is clearly a semantic difference between `'enum` and `'custom`.
