### PR TITLE
Leona will attempt to resolve enums/sets from symbols

### DIFF
--- a/test/leona/schema_test.clj
+++ b/test/leona/schema_test.clj
@@ -130,6 +130,13 @@
   (is (= {:objects {:test {:fields {:b {:type '(list :a)}}}} :enums {:a {:values [:baz :bar :foo]}}}
          (schema/transform ::test))))
 
+(deftest schema-enum-symbol-test
+  (def my-set #{:foo :bar :baz})
+  (s/def ::a my-set)
+  (s/def ::test (s/keys :req-un [::a]))
+  (is (= {:objects {:test {:fields {:a {:type '(non-null :a)}}}} :enums {:a {:values [:baz :bar :foo]}}}
+         (schema/transform ::test))))
+
 (deftest schema-req-un-reference-test
   (s/def ::a int?)
   (s/def ::b (s/keys :req-un [::a]))


### PR DESCRIPTION
Previously, the following code would not transform:

```clojure
(def my-set #{:foo :bar :baz})
(s/def ::a my-set)
(s/def ::test (s/keys :req-un [::a]))
(schema/transform ::test)
```
It would complain about `::a` not being transformable, and this is because as spec-tools walked the specs it didn't know what to do with this symbol. This is pretty unfortunate because this is a common pattern. This PR resolves this shortcoming.
