### PR TITLE
Add attach-object

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ If you'd like to add a description to the schema you can also use the `spec` fun
 (s/def ::object (st/spec string? {:description "This is my object}))
 ```
 
+Sometimes, you may want to add a custom object that’s not referred to in any of your queries, mutations or field resolvers (e.g., if you want to refer to it from an external schema attached via `attach-schema`). For this use case, Leona provides `attach-object`:
+
+```clojure
+(-> (leona/create)
+    ...
+    (leona/attach-object :some/object))
+```
+
+
 ## Notes
 
 The ordering of `attach-*` fns does not matter, other than for middleware.

--- a/src/leona/core.clj
+++ b/src/leona/core.clj
@@ -113,6 +113,12 @@
   {:pre [(s/valid? ::pre-compiled-data m)]}
   (update m :middleware conj middleware-fn))
 
+(defn attach-object
+  "Adds an object (not referred to by a query, mutation, or field resolver) into the provided pre-compiled data structure"
+  [m object-spec]
+  {:pre [(s/valid? ::pre-compiled-data m)]}
+  (update m :specs conj object-spec))
+
 (defn attach-query
   "Adds a query resolver into the provided pre-compiled data structure"
   #_([m resolver]

--- a/test/leona/core_test.clj
+++ b/test/leona/core_test.clj
@@ -75,6 +75,17 @@
              :mutations
              (update :droid dissoc :resolve)))))
 
+(deftest attach-object-test
+  (is (= (-> (leona/create)
+             (leona/attach-object ::test/human)
+             (leona/generate)
+             (get-in [:objects :human :fields]))
+         '{:home_planet {:type (non-null String)},
+           :id {:type (non-null Int)},
+           :name {:type (non-null String)},
+           :appears_in {:type (non-null (list (non-null :episode)))},
+           :episode {:type :episode}})))
+
 (deftest query-valid-test
   (let [appears-in-str (name (util/clj-name->qualified-gql-name ::test/appears-in))
         compiled-schema (-> (leona/create)


### PR DESCRIPTION
This PR adds support for adding an object to Leona schema that isn't otherwise referenced by queries, mutations, or field resolvers.

This can be useful, e.g.,  when that field is referred to in an external schema (attached via `attach-schema`), or for documenting legacy types.