### PR TITLE
Enums are now extracted from queries and mutations

### DIFF
--- a/test/leona/core_test.clj
+++ b/test/leona/core_test.clj
@@ -101,6 +101,19 @@
     (is (= true (get-in result [:data :droid :operational_QMARK_])))
     (is (= '(:NEWHOPE :EMPIRE :JEDI) (get-in result [:data :droid (keyword appears-in-str)])))))
 
+(deftest query-with-enum-valid-test
+  (let [appears-in-str (name (util/clj-name->qualified-gql-name ::test/appears-in))
+        compiled-schema (-> (leona/create)
+                            (leona/attach-query ::test/another-droid-query ::test/droid droid-resolver)
+                            (leona/compile))
+        result (leona/execute compiled-schema
+                              (format "query { droid(id: 1001, %s: NEWHOPE, test_query_enum: b) { name, operational_QMARK_, %s }}"
+                                      appears-in-str
+                                      appears-in-str))]
+    (is (= "R2D2" (get-in result [:data :droid :name])))
+    (is (= true (get-in result [:data :droid :operational_QMARK_])))
+    (is (= '(:NEWHOPE :EMPIRE :JEDI) (get-in result [:data :droid (keyword appears-in-str)])))))
+
 (deftest query-invalid-gql-test
   (let [compiled-schema (-> (leona/create)
                             (leona/attach-query ::test/droid-query ::test/droid droid-resolver)

--- a/test/leona/test_spec.clj
+++ b/test/leona/test_spec.clj
@@ -31,3 +31,8 @@
 
 (s/def ::droid-mutation (s/keys :req-un [::id]
                                 :opt-un [::primary-functions]))
+
+(s/def ::test-query-enum #{:a :b :c})
+(s/def ::another-droid-query (s/keys :req-un [::id
+                                              ::test-query-enum]
+                                     :opt [::appears-in]))


### PR DESCRIPTION
This fixes https://github.com/WorksHub/leona/issues/15

Enums are now extracted from any queries or mutations that are attached, similarly to how input objects are extracted. Previously, enums _had_ to appear in other objects to be included.