### PR TITLE
Fix support queries with no arguments (issue #12)

### DIFF
--- a/src/leona/schema.clj
+++ b/src/leona/schema.clj
@@ -113,6 +113,11 @@
          (throw (Exception. (str "Spec could not be transformed: " field))) ;; TODO improve this error
          result)))))
 
+;; nil? special case for no-args queries
+(defmethod accept-spec 'clojure.core/nil? [_ spec _ opts]
+  (let [title (spec-name-or-alias spec opts)]
+    (non-null {:objects {title {:fields {}}}})))
+
 ;; any? (one-of [(return nil) (any-printable)])
 (defmethod accept-spec 'clojure.core/any? [_ _ _ _] {})
 

--- a/test/leona/core_test.clj
+++ b/test/leona/core_test.clj
@@ -398,3 +398,20 @@
     (is (= #{:baz :qux} (set (get-in r [:generated :enums :selector :values]))))
     (let [r (leona/execute r "query { my_foo_object(selector: foo) { value }}")]
       (is (= 123 (get-in r [:data :my_foo_object :value]))))))
+
+;;
+
+(deftest no-args-query-test
+  (s/def ::no-args nil?)
+  (s/def ::result string?)
+  (s/def ::my-query (s/keys :req-un [::result]))
+
+  (defn my-query-resolver [ctx args value]
+    {:result "hello"})
+
+  (def schema
+    (-> (leona/create)
+        (leona/attach-query ::no-args ::my-query my-query-resolver)
+        (leona/compile)))
+  (let [r (leona/execute schema "{ my_query { result } }")]
+    (is (= "hello"  (get-in r [:data :my_query :result])))))


### PR DESCRIPTION
The no-args query now works by specifying as `nil?`. The `nil?` is translated to an empty object to make lacinia happy.