### PR TITLE
Update the casing system to respect context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,6 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
-## [Unreleased]
+## [0.2.0]
 ### Changed
-- Add a new arity to `make-widget-async` to provide a different widget shape.
-
-## [0.1.1] - 2018-10-22
-### Changed
-- Documentation on how to make the widgets.
-
-### Removed
-- `make-widget-sync` - we're all async, all the time.
-
-### Fixed
-- Fixed widget maker to keep working when daylight savings switches over.
-
-## 0.1.0 - 2018-10-22
-### Added
-- Files from the new template.
-- Widget maker public API - `make-widget-sync`.
-
-[Unreleased]: https://github.com/your-name/leona/compare/0.1.1...HEAD
-[0.1.1]: https://github.com/your-name/leona/compare/0.1.0...0.1.1
+- BREAKING Leona no longer defaults to snake_case for everything. Instead, objects, fields/queries/mutations and enums use the GraphQL preferred format, which is PascalCase, camelCase and SCREAMING_SNAKE_CASE respectively.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ A toolbox designed to make working with GraphQL and clojure.spec a more pleasant
 
 Leona can build Lacinia schema just by telling it the queries and mutations you want to make. You can add resolvers for specific fields and add middleware inside the executor.
 
+## Change Log
+Major changes will be documented in the [changelog](CHANGELOG.md) .   
+**BREAKING CHANGES IN 0.2.x**
+
 ## Quick Usage
 
 ``` clojure

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject workshub/leona "0.1.17-SNAPSHOT"
+(defproject workshub/leona "0.2.0-SNAPSHOT"
   :description "A pipeline for working with clojure.spec and GraphQL"
   :url "https://github.com/WorksHub/leona"
   :license {:name "Eclipse Public License"

--- a/src/leona/util.clj
+++ b/src/leona/util.clj
@@ -1,5 +1,6 @@
 (ns leona.util
   (:require [camel-snake-kebab.core :as csk]
+            [clojure.spec.alpha :as s]
             [clojure.string :as str]))
 
 (defn replace-punctuation
@@ -14,25 +15,97 @@
       (str/replace #"_QMARK_" "?")
       (str/replace #"_XMARK_" "!")))
 
-(defn clj-name->gql-name
-  [t]
+(defn- split-keep-delim
+  [s re-delim]
+  (let [m (.matcher re-delim s)]
+    ((fn step [last-end]
+       (if (.find m)
+         (let [start (.start m)
+               end (.end m)
+               delim (.group m)
+               new-head (if (not= last-end start)
+                          [(.substring s last-end start) delim]
+                          [delim])]
+           (concat new-head (lazy-seq (step end))))
+         (if (not= last-end (.length s))
+           [(.substring s last-end)]
+           []))) 0)))
+
+(defn- case-change-impl
+  [f s]
+  (str/join ""
+            (map (fn [t] (if (str/starts-with? (str t) "_")
+                           (str t)
+                           (f t)))
+                 (split-keep-delim s #"[__|___]"))))
+
+(def PascalCase
+  (partial case-change-impl csk/->PascalCase))
+
+(def camelCase
+  (partial case-change-impl csk/->camelCase))
+
+(def snake_case
+  (partial case-change-impl csk/->snake_case))
+
+(def SCREAMING_SNAKE_CASE
+  (partial case-change-impl csk/->SCREAMING_SNAKE_CASE))
+
+(defn- kebab-case
+  [s]
+  (str/join ""
+            (map (fn [t] (if (contains? (set "./") (str t))
+                           (str t)
+                           (csk/->kebab-case t)))
+                 (split-keep-delim s #"[.|/]"))))
+
+(defn clj-name->gql-name-impl
+  [f t]
   (-> t
       (name)
-      (csk/->snake_case)
+      (f)
       (replace-punctuation)
       (keyword)))
 
-(defn clj-name->qualified-gql-name
-  [t]
+(defn clj-name->qualified-gql-name-impl
+  [f t]
   (let [t (if (str/starts-with? (str t) ":")
             (-> t str (subs 1))
-            (str t))]
-    (-> t
-        (csk/->snake_case)
-        (str/replace #"\." "__")
-        (str/replace #"\/" "___")
-        (replace-punctuation)
-        (keyword))))
+            (str t))
+        t' (-> t
+               (str/replace #"\." "__")
+               (str/replace #"\/" "___"))
+        [start end] (str/split t' #"___")]
+    (if end
+      (-> (str (snake_case start)
+               "___"
+               (-> end
+                   (f)
+                   (replace-punctuation)))
+          (keyword))
+      (-> start
+          (f)
+          (replace-punctuation)
+          (keyword)))))
+
+(def clj-name->gql-name
+  (partial clj-name->gql-name-impl camelCase))
+
+(def clj-name->gql-object-name
+  (partial clj-name->gql-name-impl PascalCase))
+
+(def clj-name->gql-enum-name
+  (partial clj-name->gql-name-impl SCREAMING_SNAKE_CASE))
+
+(def clj-name->qualified-gql-name
+  (partial clj-name->qualified-gql-name-impl camelCase))
+
+(def clj-name->qualified-gql-object-name
+  (partial clj-name->qualified-gql-name-impl PascalCase))
+
+(def clj-name->qualified-gql-enum-name
+  (partial clj-name->qualified-gql-name-impl SCREAMING_SNAKE_CASE))
+
 
 (defn gql-name->clj-name
   [t]
@@ -41,5 +114,44 @@
       (str/replace #"___" "/")
       (str/replace #"__" ".")
       (replace-placeholders)
-      (csk/->kebab-case)
+      (kebab-case)
       (keyword)))
+
+(defn find-case-match
+  "In this fn we attempt to contains? k on m (map or set), but we spin through some cases and return the one that fits"
+  ([m t] ;; this is simply necessary to keep csk loaded
+   (find-case-match
+     m t [csk/->camelCase
+          csk/->PascalCase
+          csk/->SCREAMING_SNAKE_CASE
+          csk/->snake_case
+          csk/->kebab-case]))
+  ([m t fns]
+   (when-let [case-fn (first fns)]
+     (let [s (if (str/starts-with? (str t) ":")
+               (-> t str (subs 1))
+               (str t))
+           new-kw (keyword (case-fn s))]
+       (if (contains? m new-kw)
+         new-kw
+         (find-case-match m t (rest fns)))))))
+
+(defn spec-keys
+  [s]
+  (let [form (s/form s)]
+    (when (and (sequential? form)
+               (= (first form) 'clojure.spec.alpha/keys))
+      (->> form
+           (rest)
+           (rest)
+           (take-nth 2)
+           (reduce concat)))))
+
+(defn remove-ns*
+  [kw]
+  (keyword (name kw)))
+
+(defn get*
+  [m kw]
+  (or (get m kw)
+      (get m (remove-ns* kw))))

--- a/test/leona/core_test.clj
+++ b/test/leona/core_test.clj
@@ -41,7 +41,7 @@
     1001 {:primary-functions ["courier" "fixer"]
           :id 1001
           :name "R2D2"
-          ::test/appears-in [:NEWHOPE :EMPIRE :JEDI]
+          ::test/appears-in [:new-hope :empire :jedi]
           :operational? true}
     1003 {:foo "bar"}
     nil))
@@ -51,14 +51,14 @@
   {:primary-functions primary-functions
    :id 1001
    :name "R2D2"
-   ::test/appears-in [:NEWHOPE :EMPIRE :JEDI]
+   ::test/appears-in [:new-hope :empire :jedi]
    :operational? true})
 
 (deftest generate-query-test
   (is (= {:droid
-          {:type :droid,
+          {:type :Droid,
            :args {:id {:type '(non-null Int)},
-                  (util/clj-name->qualified-gql-name ::test/appears-in) {:type '(list :episode)}}}}
+                  (util/clj-name->qualified-gql-name ::test/appears-in) {:type '(list :Episode)}}}}
          (-> (leona/create)
              (leona/attach-query ::test/droid-query ::test/droid droid-resolver)
              (leona/generate)
@@ -67,9 +67,9 @@
 
 (deftest generate-mutation-test
   (is (= {:droid
-          {:type :droid,
+          {:type :Droid,
            :args {:id {:type '(non-null Int)},
-                  :primary_functions {:type '(list String)}}}}
+                  :primaryFunctions {:type '(list String)}}}}
          (-> (leona/create)
              (leona/attach-mutation ::test/droid-mutation ::test/droid droid-mutator)
              (leona/generate)
@@ -80,13 +80,13 @@
   (let [schema (-> (leona/create)
                    (leona/attach-object ::test/human :input? true)
                    (leona/generate))
-        expected-object '{:home_planet {:type (non-null String)},
+        expected-object '{:homePlanet {:type (non-null String)},
                           :id {:type (non-null Int)},
                           :name {:type (non-null String)},
-                          :appears_in {:type (non-null (list (non-null :episode)))},
-                          :episode {:type :episode}}]
-    (is (= (get-in schema [:objects :human :fields]) expected-object))
-    (is (= (get-in schema [:input-objects :human_input :fields]) expected-object))))
+                          :appearsIn {:type (non-null (list (non-null :Episode)))},
+                          :episode {:type :Episode}}]
+    (is (= (get-in schema [:objects :Human :fields]) expected-object))
+    (is (= (get-in schema [:input-objects :HumanInput :fields]) expected-object))))
 
 (deftest query-valid-test
   (let [appears-in-str (name (util/clj-name->qualified-gql-name ::test/appears-in))
@@ -94,12 +94,12 @@
                             (leona/attach-query ::test/droid-query ::test/droid droid-resolver)
                             (leona/compile))
         result (leona/execute compiled-schema
-                              (format "query { droid(id: 1001, %s: NEWHOPE) { name, operational_QMARK_, %s }}"
+                              (format "query { droid(id: 1001, %s: NEW_HOPE) { name, operational_QMARK_, %s }}"
                                       appears-in-str
                                       appears-in-str))]
     (is (= "R2D2" (get-in result [:data :droid :name])))
     (is (= true (get-in result [:data :droid :operational_QMARK_])))
-    (is (= '(:NEWHOPE :EMPIRE :JEDI) (get-in result [:data :droid (keyword appears-in-str)])))))
+    (is (= '(:NEW_HOPE :EMPIRE :JEDI) (get-in result [:data :droid (keyword appears-in-str)])))))
 
 (deftest query-with-enum-valid-test
   (let [appears-in-str (name (util/clj-name->qualified-gql-name ::test/appears-in))
@@ -107,12 +107,12 @@
                             (leona/attach-query ::test/another-droid-query ::test/droid droid-resolver)
                             (leona/compile))
         result (leona/execute compiled-schema
-                              (format "query { droid(id: 1001, %s: NEWHOPE, test_query_enum: b) { name, operational_QMARK_, %s }}"
+                              (format "query { droid(id: 1001, %s: NEW_HOPE, testQueryEnum: B) { name, operational_QMARK_, %s }}"
                                       appears-in-str
                                       appears-in-str))]
     (is (= "R2D2" (get-in result [:data :droid :name])))
     (is (= true (get-in result [:data :droid :operational_QMARK_])))
-    (is (= '(:NEWHOPE :EMPIRE :JEDI) (get-in result [:data :droid (keyword appears-in-str)])))))
+    (is (= '(:NEW_HOPE :EMPIRE :JEDI) (get-in result [:data :droid (keyword appears-in-str)])))))
 
 (deftest query-invalid-gql-test
   (let [compiled-schema (-> (leona/create)
@@ -146,10 +146,10 @@
                             (leona/attach-mutation ::test/droid-mutation ::test/droid droid-mutator)
                             (leona/compile))
         result (leona/execute compiled-schema
-                              "mutation { droid(id: 1001, primary_functions: [\"beep\"]) { name, operational_QMARK_, primary_functions }}")]
+                              "mutation { droid(id: 1001, primaryFunctions: [\"beep\"]) { name, operational_QMARK_, primaryFunctions }}")]
     (is (= "R2D2"   (get-in result [:data :droid :name])))
     (is (= true     (get-in result [:data :droid :operational_QMARK_])))
-    (is (= ["beep"] (get-in result [:data :droid :primary_functions])))))
+    (is (= ["beep"] (get-in result [:data :droid :primaryFunctions])))))
 
 (deftest mutation-invalid-gql-test
   (let [compiled-schema (-> (leona/create)
@@ -190,7 +190,7 @@
         compiled-schema (-> (leona/create)
                             (leona/attach-query ::test-query ::test resolver)
                             (leona/compile))
-        result (leona/execute compiled-schema "query Test($input: input_input!) { test(input: $input) { num }}" {:input {:num 1, :nums [2 3]}} {})]
+        result (leona/execute compiled-schema "query test($input: InputInput!) { test(input: $input) { num }}" {:input {:num 1, :nums [2 3]}} {})]
     (is (= 6 (get-in result [:data :test :num])))))
 
 ;;;;;
@@ -209,7 +209,7 @@
         compiled-schema (-> (leona/create)
                             (leona/attach-query ::test-query2 ::test resolver)
                             (leona/compile))
-        result (leona/execute compiled-schema "query Test($test_query: test_query_input!) { test(test_query: $test_query) { num }}"
+        result (leona/execute compiled-schema "query test($test_query: TestQueryInput!) { test(testQuery: $test_query) { num }}"
                               {:test_query {:input {:num 1, :nums [2 3]}}} {})]
     (is (= 6 (get-in result [:data :test :num])))))
 
@@ -230,7 +230,7 @@
         compiled-schema (-> (leona/create)
                             (leona/attach-query ::test-query ::test resolver)
                             (leona/compile))
-        result (leona/execute compiled-schema "query Test($inputs: [input_input!]!) { test(inputs: $inputs) { num }}" {:inputs [{:num 1, :nums [2 3]}]} {})]
+        result (leona/execute compiled-schema "query test($inputs: [InputInput!]!) { test(inputs: $inputs) { num }}" {:inputs [{:num 1, :nums [2 3]}]} {})]
     (is (= 6 (get-in result [:data :test :num])))))
 
 
@@ -271,7 +271,7 @@
   (let [human {:home-planet "Naboo"
                :id 123145
                :name "Jack Solo"
-               :appears-in #{:JEDI}}
+               :appears-in #{:jedi}}
         human-resolver (fn [ctx query value] human)
         compiled-schema (-> (leona/create)
                             (leona/attach-query ::test/droid-query ::test/droid droid-resolver)
@@ -290,7 +290,7 @@
               (leona/attach-query ::test-query ::test droid-resolver)
               (leona/attach-field-resolver ::b (constantly {:a 123}))
               (leona/generate))]
-    (is (get-in r [:objects :test :fields :b :resolve]))))
+    (is (get-in r [:objects :Test :fields :b :resolve]))))
 
 (deftest field-resolver-coll-included-test
   (s/def ::a int?)
@@ -302,7 +302,7 @@
               (leona/attach-query ::test-query ::test droid-resolver)
               (leona/attach-field-resolver ::c (constantly {:a 123}))
               (leona/generate))]
-    (is (get-in r [:objects :test :fields :c :resolve]))))
+    (is (get-in r [:objects :Test :fields :c :resolve]))))
 
 (deftest field-resolver-coll-included-in-ref-test
   (s/def ::a int?)
@@ -314,7 +314,7 @@
               (leona/attach-query ::test-query ::test droid-resolver)
               (leona/attach-field-resolver ::a (constantly {:a 123}))
               (leona/generate))]
-    (is (get-in r [:objects :b :fields :a :resolve]))))
+    (is (get-in r [:objects :B :fields :a :resolve]))))
 
 ;;;;;;;
 
@@ -357,8 +357,8 @@
               (leona/attach-query ::foo-query-args ::my-foo-object (constantly nil))
               (leona/attach-type-alias :foo/status :foo-status)
               (leona/generate))]
-    (is (= '(non-null :foo_status) (get-in r [:objects :my_foo_object :fields :status :type])))
-    (is (= #{:a :b :c} (set (get-in r [:enums :foo_status :values]))))))
+    (is (= '(non-null :FooStatus) (get-in r [:objects :MyFooObject :fields :status :type])))
+    (is (= #{:A :B :C} (set (get-in r [:enums :FooStatus :values]))))))
 
 (deftest add-alias-medium-test
   (s/def :foo/status #{:a :b :c})
@@ -372,12 +372,12 @@
               (leona/attach-query ::query-args ::my-bar-object (constantly {:status :d}))
               (leona/attach-type-alias :foo/status :foo-status)
               (leona/compile))]
-    (is (= '(non-null :foo_status) (get-in r [:generated :objects :my_foo_object :fields :status :type])))
-    (is (= '(non-null :status) (get-in r [:generated :objects :my_bar_object :fields :status :type])))
-    (is (= #{:a :b :c} (set (get-in r [:generated :enums :foo_status :values]))))
-    (is (= #{:d :e :f} (set (get-in r [:generated :enums :status :values]))))
-    (let [r (leona/execute r "query { my_foo_object(my_query_var: 1001) { status }}")]
-      (is (= :a (get-in r [:data :my_foo_object :status]))))))
+    (is (= '(non-null :FooStatus) (get-in r [:generated :objects :MyFooObject :fields :status :type])))
+    (is (= '(non-null :Status) (get-in r [:generated :objects :MyBarObject :fields :status :type])))
+    (is (= #{:A :B :C} (set (get-in r [:generated :enums :FooStatus :values]))))
+    (is (= #{:D :E :F} (set (get-in r [:generated :enums :Status :values]))))
+    (let [r (leona/execute r "query { myFooObject(myQueryVar: 1001) { status }}")]
+      (is (= :A (get-in r [:data :myFooObject :status]))))))
 
 (deftest add-alias-in-query-test
   (s/def ::value int?)
@@ -392,26 +392,20 @@
               (leona/attach-query ::bar-query-args ::my-bar-object (constantly {:value 456 :selector :qux}))
               (leona/attach-type-alias :foo/selector :foo-status)
               (leona/compile))]
-    (is (= '(non-null :foo_status) (get-in r [:generated :objects :my_foo_object :fields :selector :type])))
-    (is (= '(non-null :foo_status) (get-in r [:generated :queries :my_foo_object :args :selector :type])))
-    (is (= #{:foo :bar} (set (get-in r [:generated :enums :foo_status :values]))))
-    (is (= #{:baz :qux} (set (get-in r [:generated :enums :selector :values]))))
-    (let [r (leona/execute r "query { my_foo_object(selector: foo) { value }}")]
-      (is (= 123 (get-in r [:data :my_foo_object :value]))))))
-
-;;
+    (is (= '(non-null :FooStatus) (get-in r [:generated :objects :MyFooObject :fields :selector :type])))
+    (is (= '(non-null :FooStatus) (get-in r [:generated :queries :myFooObject :args :selector :type])))
+    (is (= #{:FOO :BAR} (set (get-in r [:generated :enums :FooStatus :values]))))
+    (is (= #{:BAZ :QUX} (set (get-in r [:generated :enums :Selector :values]))))
+    (let [r (leona/execute r "query { myFooObject(selector: FOO) { value }}")]
+      (is (= 123 (get-in r [:data :myFooObject :value]))))))
 
 (deftest no-args-query-test
   (s/def ::no-args nil?)
   (s/def ::result string?)
   (s/def ::my-query (s/keys :req-un [::result]))
-
-  (defn my-query-resolver [ctx args value]
-    {:result "hello"})
-
-  (def schema
-    (-> (leona/create)
-        (leona/attach-query ::no-args ::my-query my-query-resolver)
-        (leona/compile)))
-  (let [r (leona/execute schema "{ my_query { result } }")]
-    (is (= "hello"  (get-in r [:data :my_query :result])))))
+  (let [my-query-resolver (fn [ctx args value] {:result "hello"})
+        schema(-> (leona/create)
+                  (leona/attach-query ::no-args ::my-query my-query-resolver)
+                  (leona/compile))
+        r (leona/execute schema "{ myQuery { result } }")]
+    (is (= "hello"  (get-in r [:data :myQuery :result])))))

--- a/test/leona/custom_scalar_test.clj
+++ b/test/leona/custom_scalar_test.clj
@@ -22,7 +22,7 @@
             ::result-1
             ::result-2
             ::result-3)]
-    (is (= r {:objects {:result_1 {:fields {:date {:type '(non-null :date)}}}, :result_2 {:fields {:num {:type :num}}}, :result_3 {:fields {:bool {:type '(non-null Boolean)}}}}}))))
+    (is (= r {:objects {:Result1 {:fields {:date {:type '(non-null :Date)}}}, :Result2 {:fields {:num {:type :Num}}}, :Result3 {:fields {:bool {:type '(non-null Boolean)}}}}}))))
 
 (deftest custom-scalar-test
   (s/def ::date tt/date-time?)
@@ -38,14 +38,14 @@
                             (leona/attach-custom-scalar ::date {:parse #(tf/parse (tf/formatters :date-time) %)
                                                                 :serialize #(tf/unparse (tf/formatters :date-time) %)})
                             (leona/compile))
-        result (leona/execute compiled-schema "query Test($date: date!) { test(date: $date) { result {date} }}" {:date (str now-date)} {})]
-    (is (= '(non-null :date) (get-in compiled-schema [:generated :queries :test :args :date :type])))
-    (is (= '(non-null :date) (get-in compiled-schema [:generated :objects :result :fields :date :type])))
+        result (leona/execute compiled-schema "query test($date: Date!) { test(date: $date) { result {date} }}" {:date (str now-date)} {})]
+    (is (= '(non-null :Date) (get-in compiled-schema [:generated :queries :test :args :date :type])))
+    (is (= '(non-null :Date) (get-in compiled-schema [:generated :objects :Result :fields :date :type])))
     (let [d (get-in result [:data :test :result :date])]
       (is (= (str (t/plus now-date (t/years 1))) d)))))
 
 (deftest custom-scalar-test--indirect
-  (s/def ::date (st/spec tt/date-time? {:type '(custom :date)})) ;; <-- Notice the use of this super special secret type symbol
+  (s/def ::date (st/spec tt/date-time? {:type '(custom :Date)})) ;; <-- Notice the use of this super special secret type symbol
   (s/def ::indirect-date ::date)
   (s/def ::result (s/keys :req-un [::indirect-date]))
   (s/def ::test (s/keys :req-un [::result]))
@@ -59,10 +59,10 @@
                             (leona/attach-custom-scalar ::date {:parse #(tf/parse (tf/formatters :date-time) %)
                                                                 :serialize #(tf/unparse (tf/formatters :date-time) %)})
                             (leona/compile))
-        result (leona/execute compiled-schema "query Test($date: date!) { test(date: $date) { result {indirect_date} }}" {:date (str now-date)} {})]
-    (is (= '(non-null :date) (get-in compiled-schema [:generated :queries :test :args :date :type])))
-    (is (= :date (get-in compiled-schema [:generated :objects :result :fields :indirect_date :type])))
-    (let [d (get-in result [:data :test :result :indirect_date])]
+        result (leona/execute compiled-schema "query test($date: Date!) { test(date: $date) { result {indirectDate} }}" {:date (str now-date)} {})]
+    (is (= '(non-null :Date) (get-in compiled-schema [:generated :queries :test :args :date :type])))
+    (is (= :Date (get-in compiled-schema [:generated :objects :Result :fields :indirectDate :type])))
+    (let [d (get-in result [:data :test :result :indirectDate])]
       (is (= (str (t/plus now-date (t/years 1))) d)))))
 
 (deftest custom-scalar-test--collection
@@ -81,9 +81,9 @@
                             (leona/attach-custom-scalar ::date {:parse #(tf/parse (tf/formatters :date-time) %)
                                                                 :serialize #(tf/unparse (tf/formatters :date-time) %)})
                             (leona/compile))
-        result (leona/execute compiled-schema "query Test($date: date!) { test(date: $date) { result {dates} }}" {:date (str now-date)} {})]
-    (is (= '(non-null :date) (get-in compiled-schema [:generated :queries :test :args :date :type])))
-    (is (= '(non-null (list (non-null :date))) (get-in compiled-schema [:generated :objects :result :fields :dates :type])))
+        result (leona/execute compiled-schema "query test($date: Date!) { test(date: $date) { result {dates} }}" {:date (str now-date)} {})]
+    (is (= '(non-null :Date) (get-in compiled-schema [:generated :queries :test :args :date :type])))
+    (is (= '(non-null (list (non-null :Date))) (get-in compiled-schema [:generated :objects :Result :fields :dates :type])))
     (let [d (get-in result [:data :test :result :dates])]
       (is (= (str (t/plus now-date (t/years 1))) (first d)))
       (is (= (str (t/minus now-date (t/years 1))) (second d))))))

--- a/test/leona/real_schema_test.clj
+++ b/test/leona/real_schema_test.clj
@@ -122,8 +122,8 @@
 (deftest real-schema-test
   (let [r (schema/transform :wh/job)]
     (is r)
-    (is (= #{:location :company :salary :job} (set (keys (:objects r)))))
-    (is (= {:role_type {:values ["Intern" "Contract" "Full_time"]}} (:enums r)))))
+    (is (= #{:Location :Company :Salary :Job} (set (keys (:objects r)))))
+    (is (= {:RoleType {:values [:INTERN :CONTRACT :FULL_TIME]}} (:enums r)))))
 
 (deftest real-compile
   (s/def ::job-input (s/keys :req-un [:wh.job/id]))

--- a/test/leona/schema_test.clj
+++ b/test/leona/schema_test.clj
@@ -8,24 +8,13 @@
              [spec-tools.core :as st]))
 
 (deftest fix-references-test
-  (let [s {:objects {:test {:fields {:b {:objects {:b {:fields {:a {:type '(non-null Int)}}}}},
-                                     :d {:objects {:d {:fields {:c {:type '(non-null String)}}}}}}}}}]
-    (is (= {:objects {:test {:fields {:b {:type :b},
-                                      :d {:type :d}}}
-                      :b {:fields {:a {:type '(non-null Int)}}}
-                      :d {:fields {:c {:type '(non-null String)}}}}}
+  (let [s {:objects {:Test {:fields {:b {:objects {:B {:fields {:a {:type '(non-null Int)}}}}},
+                                     :d {:objects {:D {:fields {:c {:type '(non-null String)}}}}}}}}}]
+    (is (= {:objects {:Test {:fields {:b {:type :B},
+                                      :d {:type :D}}}
+                      :B {:fields {:a {:type '(non-null Int)}}}
+                      :D {:fields {:c {:type '(non-null String)}}}}}
            (schema/fix-references s)))))
-
-(deftest valid-enum?-test
-  (is (schema/valid-enum? [:foo :bar :baz]))
-  (is (schema/valid-enum? ["foo" "bar" "baz"]))
-  (is (schema/valid-enum? [:foo_one :bar_two :baz_three]))
-  (is (schema/valid-enum? ["foo_one" "bar_two" "baz_three"]))
-  (is (schema/valid-enum? ["fooOne" "barTwo" "bazThree"]))
-  (is (not (schema/valid-enum? [1 2 3])))
-  (is (not (schema/valid-enum? ["foo one" "bar two" "baz three"])))
-  (is (not (schema/valid-enum? ["foo-one" "bar-two" "baz-three"])))
-  (is (not (schema/valid-enum? [:foo-one :bar-two :baz-three]))))
 
 (deftest valid-replacement-type?-test
   (is (schema/valid-replacement-type? 'String))
@@ -47,94 +36,94 @@
 (deftest schema-req-test
   (s/def ::a int?)
   (s/def ::test (s/keys :req [::a]))
-  (is (= {:objects {:test {:fields {(util/clj-name->qualified-gql-name ::a) {:type '(non-null Int)}}}}}
+  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a) {:type '(non-null Int)}}}}}
          (schema/transform ::test))))
 
 (deftest schema-req-with-nilable-test
   (s/def ::a (s/nilable int?))
   (s/def ::test (s/keys :req [::a]))
-  (is (= {:objects {:test {:fields {(util/clj-name->qualified-gql-name ::a) {:type '(non-null Int)}}}}}
+  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a) {:type '(non-null Int)}}}}}
          (schema/transform ::test))))
 
 (deftest schema-req-un-test
   (s/def ::a string?)
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type '(non-null String)}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type '(non-null String)}}}}}
          (schema/transform ::test))))
 
 (deftest schema-req-un-with-nilable-test
   (s/def ::a (s/nilable string?))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type 'String}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type 'String}}}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-test
   (s/def ::a int?)
   (s/def ::test (s/keys :opt [::a]))
-  (is (= {:objects {:test {:fields {(util/clj-name->qualified-gql-name ::a) {:type 'Int}}}}}
+  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a) {:type 'Int}}}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-with-nilable-test
   (s/def ::a (s/nilable int?))
   (s/def ::test (s/keys :opt [::a]))
-  (is (= {:objects {:test {:fields {(util/clj-name->qualified-gql-name ::a) {:type 'Int}}}}}
+  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a) {:type 'Int}}}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-un-test
   (s/def ::a string?)
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type 'String}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type 'String}}}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-un-with-nilable-test
   (s/def ::a (s/nilable string?))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type 'String}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type 'String}}}}}
          (schema/transform ::test))))
 
 (deftest schema-req-list-test
   (s/def ::a (s/coll-of string?))
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type '(non-null (list (non-null String)))}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type '(non-null (list (non-null String)))}}}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-list-test
   (s/def ::a (s/coll-of string?))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type '(list String)}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type '(list String)}}}}}
          (schema/transform ::test))))
 
 (deftest schema-req-enum-test
   (s/def ::a #{:foo :bar :baz})
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type '(non-null :a)}}}} :enums {:a {:values [:baz :bar :foo]}}}
+  (is (= {:objects {:Test {:fields {:a {:type '(non-null :A)}}}} :enums {:A {:values [:BAZ :BAR :FOO]}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-enum-test
   (s/def ::a #{:foo :bar :baz})
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type :a}}}} :enums {:a {:values [:baz :bar :foo]}}}
+  (is (= {:objects {:Test {:fields {:a {:type :A}}}} :enums {:A {:values [:BAZ :BAR :FOO]}}}
          (schema/transform ::test))))
 
 (deftest schema-req-enum-list-test
   (s/def ::a #{:foo :bar :baz})
   (s/def ::b (s/coll-of ::a))
   (s/def ::test (s/keys :req-un [::b]))
-  (is (= {:objects {:test {:fields {:b {:type '(non-null (list (non-null :a)))}}}} :enums {:a {:values [:baz :bar :foo]}}}
+  (is (= {:objects {:Test {:fields {:b {:type '(non-null (list (non-null :A)))}}}} :enums {:A {:values [:BAZ :BAR :FOO]}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-enum-list-test
   (s/def ::a #{:foo :bar :baz})
   (s/def ::b (s/coll-of ::a))
   (s/def ::test (s/keys :opt-un [::b]))
-  (is (= {:objects {:test {:fields {:b {:type '(list :a)}}}} :enums {:a {:values [:baz :bar :foo]}}}
+  (is (= {:objects {:Test {:fields {:b {:type '(list :A)}}}} :enums {:A {:values [:BAZ :BAR :FOO]}}}
          (schema/transform ::test))))
 
 (deftest schema-enum-symbol-test
   (def my-set #{:foo :bar :baz})
   (s/def ::a my-set)
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type '(non-null :a)}}}} :enums {:a {:values [:baz :bar :foo]}}}
+  (is (= {:objects {:Test {:fields {:a {:type '(non-null :A)}}}} :enums {:A {:values [:BAZ :BAR :FOO]}}}
          (schema/transform ::test))))
 
 (deftest schema-req-un-reference-test
@@ -143,10 +132,10 @@
   (s/def ::c string?)
   (s/def ::d (s/keys :req-un [::c]))
   (s/def ::test (s/keys :req-un [::b ::d]))
-  (is (= {:objects {:b {:fields {:a {:type '(non-null Int)}}}
-                    :d {:fields {:c {:type '(non-null String)}}}
-                    :test {:fields {:b {:type '(non-null :b)},
-                                    :d {:type '(non-null :d)}}}}}
+  (is (= {:objects {:B {:fields {:a {:type '(non-null Int)}}}
+                    :D {:fields {:c {:type '(non-null String)}}}
+                    :Test {:fields {:b {:type '(non-null :B)},
+                                    :d {:type '(non-null :D)}}}}}
          (schema/transform ::test))))
 
 (deftest schema-req-un-reference-opt-un-coll-test
@@ -154,8 +143,8 @@
   (s/def ::b (s/keys :req-un [::a]))
   (s/def ::c (s/coll-of ::b))
   (s/def ::test (s/keys :opt-un [::c]))
-  (is (= {:objects {:b {:fields {:a {:type '(non-null Int)}}}
-                    :test {:fields {:c {:type '(list :b)}}}}}
+  (is (= {:objects {:B {:fields {:a {:type '(non-null Int)}}}
+                    :Test {:fields {:c {:type '(list :B)}}}}}
          (schema/transform ::test))))
 
 (deftest schema-req-un-reference-req-un-coll-test
@@ -163,8 +152,8 @@
   (s/def ::b (s/keys :req-un [::a]))
   (s/def ::c (s/coll-of ::b))
   (s/def ::test (s/keys :req-un [::c]))
-  (is (= {:objects {:b {:fields {:a {:type '(non-null Int)}}}
-                    :test {:fields {:c {:type '(non-null (list (non-null :b)))}}}}}
+  (is (= {:objects {:B {:fields {:a {:type '(non-null Int)}}}
+                    :Test {:fields {:c {:type '(non-null (list (non-null :B)))}}}}}
          (schema/transform ::test))))
 
 (deftest schema-reference-name-req-req-test
@@ -172,8 +161,8 @@
   (s/def ::b (s/keys :req-un [::a]))
   (s/def ::c ::b)
   (s/def ::test (s/keys :req-un [::c]))
-  (is (= {:objects {:b {:fields {:a {:type '(non-null Int)}}}
-                    :test {:fields {:c {:type '(non-null :b)},}}}}
+  (is (= {:objects {:B {:fields {:a {:type '(non-null Int)}}}
+                    :Test {:fields {:c {:type '(non-null :B)}}}}}
          (schema/transform ::test))))
 
 (deftest schema-reference-name-opt-req-test
@@ -181,8 +170,8 @@
   (s/def ::b (s/keys :opt-un [::a]))
   (s/def ::c ::b)
   (s/def ::test (s/keys :req-un [::c]))
-  (is (= {:objects {:b {:fields {:a {:type 'Int}}}
-                    :test {:fields {:c {:type '(non-null :b)},}}}}
+  (is (= {:objects {:B {:fields {:a {:type 'Int}}}
+                    :Test {:fields {:c {:type '(non-null :B)}}}}}
          (schema/transform ::test))))
 
 (deftest schema-reference-name-opt-opt-test
@@ -190,8 +179,8 @@
   (s/def ::b (s/keys :opt-un [::a]))
   (s/def ::c ::b)
   (s/def ::test (s/keys :opt-un [::c]))
-  (is (= {:objects {:b {:fields {:a {:type 'Int}}}
-                    :test {:fields {:c {:type :b},}}}}
+  (is (= {:objects {:B {:fields {:a {:type 'Int}}}
+                    :Test {:fields {:c {:type :B},}}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-un-reference-test
@@ -200,10 +189,10 @@
   (s/def ::c string?)
   (s/def ::d (s/keys :opt-un [::c]))
   (s/def ::test (s/keys :opt-un [::b ::d]))
-  (is (= {:objects {:b {:fields {:a {:type 'Int}}}
-                    :d {:fields {:c {:type 'String}}}
-                    :test {:fields {:b {:type :b},
-                                    :d {:type :d}}}}}
+  (is (= {:objects {:B {:fields {:a {:type 'Int}}}
+                    :D {:fields {:c {:type 'String}}}
+                    :Test {:fields {:b {:type :B},
+                                    :d {:type :D}}}}}
          (schema/transform ::test))))
 
 (deftest schema-merge-test
@@ -212,7 +201,7 @@
   (s/def ::c string?)
   (s/def ::d (s/keys :opt-un [::c]))
   (s/def ::test (s/merge ::b ::d))
-  (is (= {:objects {:test {:fields {:a {:type 'Int},
+  (is (= {:objects {:Test {:fields {:a {:type 'Int},
                                     :c {:type 'String}}}}}
          (schema/transform ::test))))
 
@@ -220,7 +209,7 @@
   "If we recognise a predicate we use that"
   (s/def ::a (s/and int? odd?))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type 'Int}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type 'Int}}}}}
          (schema/transform ::test))))
 
 (deftest schema-and-test-fail
@@ -233,7 +222,7 @@
   "If we recognise a predicate we use that"
   (s/def ::a (s/or :int int? :odd odd?))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type 'Int}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type 'Int}}}}}
          (schema/transform ::test))))
 
 (deftest schema-or-test-fail
@@ -259,22 +248,22 @@
 
 (def result
   {:objects
-   {:human
+   {:Human
     {:fields
-     {:home_planet {:type '(non-null String)},
+     {:homePlanet {:type '(non-null String)},
       :id {:type '(non-null Int)},
       :name {:type '(non-null String)},
-      :appears_in {:type '(non-null (list (non-null :episode)))},
-      :episode {:type :episode}}},
-    :droid
+      :appearsIn {:type '(non-null (list (non-null :Episode)))},
+      :episode {:type :Episode}}},
+    :Droid
     {:fields
-     {:primary_functions {:type '(non-null (list (non-null String)))},
+     {:primaryFunctions {:type '(non-null (list (non-null String)))},
       :id {:type '(non-null Int)},
       :name {:type '(non-null String)},
-      :owner      {:type :human},
-      (util/clj-name->qualified-gql-name ::test/appears-in) {:type '(non-null (list (non-null :episode)))},
+      :owner      {:type :Human},
+      (util/clj-name->qualified-gql-name ::test/appears-in) {:type '(non-null (list (non-null :Episode)))},
       :operational_QMARK_ {:type 'Boolean}}}},
-   :enums {:episode {:values [:EMPIRE :NEWHOPE :JEDI]}}})
+   :enums {:Episode {:values [:JEDI :NEW_HOPE :EMPIRE]}}})
 
 (deftest comprehensive-schema-test
   (is (= result
@@ -286,25 +275,25 @@
 (deftest schema-description-test
   (s/def ::a (st/spec int? {:description "FooBarBaz"}))
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type '(non-null Int) :description "FooBarBaz"}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type '(non-null Int) :description "FooBarBaz"}}}}}
          (schema/transform ::test))))
 
 (deftest schema-type-test
   (s/def ::a (st/spec int? {:type 'Boolean}))
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type 'Boolean}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type 'Boolean}}}}}
          (schema/transform ::test))))
 
 (deftest schema-type-enum-test
   (s/def ::a (st/spec int? {:type '(enum :foo)}))
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type :foo}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type :foo}}}}}
          (schema/transform ::test))))
 
 (deftest schema-type-kw-ignored-test
   (s/def ::a (st/spec int? {:type :foo}))
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:test {:fields {:a {:type '(non-null Int)}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type '(non-null Int)}}}}}
          (schema/transform ::test))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -312,14 +301,14 @@
 (deftest type-alias-enum-test
   (s/def :foo/status #{:a :b :c})
   (s/def ::test (s/keys :req-un [:foo/status]))
-  (is (= {:objects {:test {:fields {:status {:type '(non-null :foo_status)}}}}
-          :enums {:foo_status {:values [:c :b :a]}}}
+  (is (= {:objects {:Test {:fields {:status {:type '(non-null :FooStatus)}}}}
+          :enums {:FooStatus {:values [:C :B :A]}}}
          (schema/transform ::test {:type-aliases {:foo/status :foo-status}}))))
 
 (deftest type-alias-object-test
   (s/def ::foo int?)
   (s/def ::bar (s/keys :opt-un [::foo]))
   (s/def ::test (s/keys :req-un [::bar]))
-  (is (= {:objects {:test {:fields {:bar {:type '(non-null :baz)}}}
-                    :baz {:fields {:foo {:type 'Int}}}}}
+  (is (= {:objects {:Test {:fields {:bar {:type '(non-null :Baz)}}}
+                    :Baz {:fields {:foo {:type 'Int}}}}}
          (schema/transform ::test {:type-aliases {::bar :baz}}))))

--- a/test/leona/test_spec.clj
+++ b/test/leona/test_spec.clj
@@ -7,7 +7,7 @@
 (s/def ::id (s/and int? odd?))
 (s/def ::name string?)
 (s/def ::operational? boolean?)
-(s/def ::episode #{:NEWHOPE :EMPIRE :JEDI})
+(s/def ::episode #{:new-hope :empire :jedi})
 (s/def ::appears-in (s/coll-of ::episode))
 
 (s/def ::human (s/keys

--- a/test/leona/util_test.clj
+++ b/test/leona/util_test.clj
@@ -1,5 +1,6 @@
 (ns leona.util-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.spec.alpha :as s]
+            [clojure.test :refer :all]
             [leona.util :as util]))
 
 (deftest replace-punctuation-test
@@ -26,6 +27,24 @@
 
 (deftest clj-name->qualified-gql-name-test
   (is (= :hello (util/gql-name->clj-name :hello)))
-  (is (= (util/gql-name->clj-name :leona__util_test___hello)))
+  (is (= :leona.util-test/hello (util/gql-name->clj-name :leona__util_test___hello)))
   (is (= ::hello? (util/gql-name->clj-name :leona__util_test___hello_QMARK_)))
   (is (= :leona.util-test/hello? (util/gql-name->clj-name :leona__util_test___hello_QMARK_))))
+
+(deftest spec-keys-test
+  (s/def ::bar int?)
+  (s/def ::baz string?)
+  (s/def ::foo (s/keys :req-un [::bar]
+                       :opt-un [::baz]))
+  (is (= '(::bar ::baz) (util/spec-keys ::foo)))
+  (is (nil? (util/spec-keys int?)))
+  (is (nil? (util/spec-keys nil?))))
+
+(deftest find-case-match
+  (is (= :foo (util/find-case-match {:foo 123} :foo)))
+  (comment (is (= :fooBar (util/find-case-match {:fooBar 123} :foo_bar)))
+           (is (= :FooBar (util/find-case-match {:FooBar 123} :foo_bar)))
+           (is (= :FOO_BAR (util/find-case-match {:FOO_BAR 123} :foo_bar)))
+           (is (= :foo_bar (util/find-case-match {:foo_bar 123} :FooBar)))
+           (is (= :foo_bar (util/find-case-match {:foo_bar 123} :fooBar)))
+           (is (= :foo_bar (util/find-case-match {:foo_bar 123} :FOO_BAR)))))


### PR DESCRIPTION
In this PR we fully revamp the casing system so that it no longer indiscriminately snake_cases everything. Now we follow the GraphQL convention of...
* PascalCase for **object names (including enum names)**
* camelCase for **query names, mutation names and field names**
* SCREAMING_SNAKE_CASE for **enum values**

Obviously this has big reverberations and affects a lot of the code base. Almost all the tests needed touching.

The motivation behind the PR is that people on the outside world are exposed to a GraphQL API which is follows the conventions and appears relatively...standard. By snake casing everything we were ignoring the suggested conventions and presented an odd looking API as a result.

The next step is to give Leona users control over exactly which casing is used where. This will appear in a follow-up PR.