### PR TITLE
Some work on #4 (s/fdef parsing) and #11 (description support),

### DIFF
--- a/src/leona/core.clj
+++ b/src/leona/core.clj
@@ -220,7 +220,7 @@
   [m access-key id opts]
   (->> m
        (map (fn [[k v]]
-              (let [{:keys [objects enums description]} (leona-schema/transform (get v access-key) opts)
+              (let [{:keys [objects enums]} (leona-schema/transform (get v access-key) opts)
                     args-object (util/clj-name->gql-object-name (get v access-key))]
                 (hash-map (util/clj-name->gql-name k)
                           (merge {:type (util/clj-name->gql-object-name k)
@@ -229,8 +229,8 @@
                                   :resolve (wrap-resolver id (:resolver v) (get v access-key) k)}
                                  (when (not-empty enums)
                                    {:enums enums})
-                                 (when description
-                                  {:description description}))))))
+                                 (when (:description v)
+                                  {:description (:description v)}))))))
        (apply merge)))
 
 (defn- extract-all

--- a/src/leona/schema.clj
+++ b/src/leona/schema.clj
@@ -219,7 +219,7 @@
 (defmethod accept-spec 'clojure.core/ratio? [_ _ _ _] {:type (non-null 'Int)})
 
 ;; bytes? (bytes)
-(defmethod accept-spec 'clojure.core/ratio? [_ _ _ _] {:type (non-null 'String)})
+(defmethod accept-spec 'clojure.core/bytes? [_ _ _ _] {:type (non-null 'String)})
 
 (defmethod accept-spec ::visitor/set [dispatch spec children opts]
   (if-let [n (spec-name-or-alias spec opts)]


### PR DESCRIPTION
 Both functional but in need of design decisions before some further work and cleanup. And tests...
There are definitely all-around better approaches with less mess - while I'm weak with macros completely avoiding them when they're around is even harder. And multiple arity doesn't really count if you gotta watch quoting your input...
fdef oughta be separate and macro'd so the main fns don't get polluted, hence fdef stuff already in its own fn. Well that and the duplication between queries and mutations. Then subscriptions I suppose? These should probably share a common setup entrypoint.

The fdef parsing is real hacky since it has to try to conform to the other arity, and having multiple sources of automagically injected truth seems ripe for mess.