### PR TITLE
implement fspec parsing and doc support

### DIFF
--- a/src/leona/core.clj
+++ b/src/leona/core.clj
@@ -167,9 +167,8 @@
 (defn parse-fspec
   "Extract :args and :ret from fdef spec"
   [resolver-var]
-  (let [spec-map (->> resolver-var
-                      s/get-spec
-                      s/form
+  (let [to-spec (s/get-spec resolver-var)
+        spec-map (->> (try (s/form to-spec) (catch IllegalArgumentException e))
                       rest
                       (apply hash-map))]
     (for [source-key [:args :ret] ;TODO naming convention for fdef ns?
@@ -197,7 +196,7 @@
   "Adds a query resolver into the provided pre-compiled data structure"
   ([m resolver]
    `(let [[query-spec# results-spec#] (parse-fspec (var ~resolver))]
-     (attach-query ~m query-spec# results-spec# ~resolver)))
+     (attach-query ~m query-spec# results-spec# ~resolver :doc (:doc (meta (var ~resolver))))))
   ([m query-spec results-spec resolver & {:keys [doc op-name]}]
    `(let [doc#      (try (:doc (meta (resolve '~resolver))) (catch ClassCastException e#))
           interned# (try (intern *ns* ~resolver) (catch ClassCastException e#))] ;also ensure let-local bindings get captured...
@@ -207,7 +206,7 @@
   "Adds a mutation resolver into the provided pre-compiled data structure"
   ([m resolver]
    `(let [[mutation-spec# results-spec#] (parse-fspec (var ~resolver))]
-     (attach-mutation ~m mutation-spec# results-spec# ~resolver)))
+     (attach-mutation ~m mutation-spec# results-spec# ~resolver :doc (:doc (meta (var ~resolver))))))
   ([m mutation-spec results-spec resolver & {:keys [doc op-name]}]
    `(let [doc#      (try (:doc (meta (resolve '~resolver))) (catch ClassCastException e#))
           interned# (try (intern *ns* ~resolver) (catch ClassCastException e#))]

--- a/test/leona/core_test.clj
+++ b/test/leona/core_test.clj
@@ -21,8 +21,10 @@
     (is (= {:specs #{::test/droid}
             :middleware [middleware]
             :queries {::test/droid {:resolver droid-resolver
+                                    :operation-key ::test/droid
                                     :query-spec ::test/droid-query}}
             :mutations {::test/droid {:resolver droid-mutator
+                                      :operation-key ::test/droid
                                       :mutation-spec ::test/droid-mutation}}
             :input-objects #{}
             :field-resolvers {::test/owner {:resolver human-resolver}}

--- a/test/leona/core_test.clj
+++ b/test/leona/core_test.clj
@@ -419,18 +419,17 @@
   (s/def ::yes true?)
   (s/def ::result (s/keys :req-un [::num ::yes]))
   (s/def ::args (s/keys :req-un [::num]))
-  (s/fdef res-defined :args ::args :ret ::result)
   (defn res-defined "A docstring"
     [ctx {:keys [num]} value]
     {:num (* num num num) :yes true})
+  (s/fdef res-defined :args ::args :ret ::result)
 
   (let [compiled-schema (-> (leona/create)
                             (leona/attach-query res-defined)
                             (leona/attach-mutation res-defined)
                             (leona/compile))
         result (leona/execute compiled-schema "{ result(num: 3) { num }}" {:num 3} {})]
-    ; (is (= "A docstring" (get-in compiled-schema [:generated :queries :result :description])))
-    ; ^ works from within same ns, otherwise not. hence (run-tests) works, lein test fails.
+    (is (= "A docstring" (get-in compiled-schema [:generated :queries :result :description])))
     (is (= 27 (get-in result [:data :result :num])))))
 
 (deftest inline-resolver-manual-description-test


### PR DESCRIPTION
Ok, I think this is about as sensible as it can get. Doesn't hurt my brain anymore anyways...

Potential to name query/operation separately from type, could use resolver-fn for operation name I reckon (also considering that's where doc gets sourced...) but here keeps present behavior/naming.

https://github.com/WorksHub/leona/issues/4