### PR TITLE
Fix unqualified name clashes when injecting field resolvers

### DIFF
--- a/src/leona/schema.clj
+++ b/src/leona/schema.clj
@@ -158,115 +158,141 @@
    :spec spec})
 
 ;; pos-int? (large-integer* {:min 1})
-(defmethod accept-spec 'clojure.core/pos-int? [_ spec _ _] {:type (non-null 'Int)
-                                                            :spec spec})
+(defmethod accept-spec 'clojure.core/pos-int? [_ spec _ _]
+  {:type (non-null 'Int)
+   :spec spec})
 
 ;; neg-int? (large-integer* {:max -1})
-(defmethod accept-spec 'clojure.core/neg-int? [_ spec _ _] {:type (non-null 'Int)
-                                                            :spec spec})
+(defmethod accept-spec 'clojure.core/neg-int? [_ spec _ _]
+  {:type (non-null 'Int)
+   :spec spec})
 
 ;; nat-int? (large-integer* {:min 0})
-(defmethod accept-spec 'clojure.core/nat-int? [_ spec _ _] {:type (non-null 'Int)
-                                                            :spec spec})
+(defmethod accept-spec 'clojure.core/nat-int? [_ spec _ _]
+  {:type (non-null 'Int)
+   :spec spec})
 
 ;; float? (double)
-(defmethod accept-spec 'clojure.core/float? [_ spec _ _] {:type (non-null 'Float)
-                                                          :spec spec})
+(defmethod accept-spec 'clojure.core/float? [_ spec _ _]
+  {:type (non-null 'Float)
+   :spec spec})
 
 ;; double? (double)
-(defmethod accept-spec 'clojure.core/double? [_ spec _ _] {:type (non-null 'Float)
-                                                           :spec spec})
+(defmethod accept-spec 'clojure.core/double? [_ spec _ _]
+  {:type (non-null 'Float)
+   :spec spec})
 
 ;; boolean? (boolean)
-(defmethod accept-spec 'clojure.core/boolean? [_ spec _ _] {:type (non-null 'Boolean)
-                                                            :spec spec})
+(defmethod accept-spec 'clojure.core/boolean? [_ spec _ _]
+  {:type (non-null 'Boolean)
+   :spec spec})
 
 ;; string? (string-alphanumeric)
-(defmethod accept-spec 'clojure.core/string? [_ spec _ _] {:type (non-null 'String)
-                                                           :spec spec})
+(defmethod accept-spec 'clojure.core/string? [_ spec _ _]
+  {:type (non-null 'String)
+   :spec spec})
 
 ;; ident? (one-of [(keyword-ns) (symbol-ns)])
-(defmethod accept-spec 'clojure.core/ident? [_ spec _ _] {:type (non-null 'String)
-                                                          :spec spec})
+(defmethod accept-spec 'clojure.core/ident? [_ spec _ _]
+  {:type (non-null 'String)
+   :spec spec})
 
 ;; simple-ident? (one-of [(keyword) (symbol)])
-(defmethod accept-spec 'clojure.core/simple-ident? [_ spec _ _] {:type (non-null 'String)
-                                                                 :spec spec})
+(defmethod accept-spec 'clojure.core/simple-ident? [_ spec _ _]
+  {:type (non-null 'String)
+   :spec spec})
 
 ;; qualified-ident? (such-that qualified? (one-of [(keyword-ns) (symbol-ns)]))
-(defmethod accept-spec 'clojure.core/qualified-ident? [_ spec _ _] {:type (non-null 'String)
-                                                                    :spec spec})
+(defmethod accept-spec 'clojure.core/qualified-ident? [_ spec _ _]
+  {:type (non-null 'String)
+   :spec spec})
 
 ;; keyword? (keyword-ns)
-(defmethod accept-spec 'clojure.core/keyword? [_ spec _ _] {:type (non-null 'String)
-                                                            :spec spec})
+(defmethod accept-spec 'clojure.core/keyword? [_ spec _ _]
+  {:type (non-null 'String)
+   :spec spec})
 
 ;; simple-keyword? (keyword)
-(defmethod accept-spec 'clojure.core/simple-keyword? [_ spec _ _] {:type (non-null 'String)
-                                                                   :spec spec})
+(defmethod accept-spec 'clojure.core/simple-keyword? [_ spec _ _]
+  {:type (non-null 'String)
+   :spec spec})
 
 ;; qualified-keyword? (such-that qualified? (keyword-ns))
-(defmethod accept-spec 'clojure.core/qualified-keyword? [_ spec _ _] {:type (non-null 'String)
-                                                                      :spec spec})
+(defmethod accept-spec 'clojure.core/qualified-keyword? [_ spec _ _]
+  {:type (non-null 'String)
+   :spec spec})
 
 ;; symbol? (symbol-ns)
-(defmethod accept-spec 'clojure.core/symbol? [_ spec _ _] {:type (non-null 'String)
-                                                           :spec spec})
+(defmethod accept-spec 'clojure.core/symbol? [_ spec _ _]
+  {:type (non-null 'String)
+   :spec spec})
 
 ;; simple-symbol? (symbol)
-(defmethod accept-spec 'clojure.core/simple-symbol? [_ spec _ _] {:type (non-null 'String)
-                                                                  :spec spec})
+(defmethod accept-spec 'clojure.core/simple-symbol? [_ spec _ _]
+  {:type (non-null 'String)
+   :spec spec})
 
 ;; qualified-symbol? (such-that qualified? (symbol-ns))
-(defmethod accept-spec 'clojure.core/qualified-symbol? [_ spec _ _] {:type (non-null 'String)
-                                                                     :spec spec})
+(defmethod accept-spec 'clojure.core/qualified-symbol? [_ spec _ _]
+  {:type (non-null 'String)
+   :spec spec})
 
 ;; uuid? (uuid)
-(defmethod accept-spec 'clojure.core/uuid? [_ spec _ _] {:type (non-null 'ID)
-                                                         :spec spec})
+(defmethod accept-spec 'clojure.core/uuid? [_ spec _ _]
+  {:type (non-null 'ID)
+   :spec spec})
 
 ;; uri? (fmap #(java.net.URI/create (str "http://" % ".com")) (uuid))
-(defmethod accept-spec 'clojure.core/uri? [_ spec _ _] {:type (non-null 'String)
-                                                        :spec spec})
+(defmethod accept-spec 'clojure.core/uri? [_ spec _ _]
+  {:type (non-null 'String)
+   :spec spec})
 
 ;; bigdec? (fmap #(BigDecimal/valueOf %)
 ;;               (double* {:infinite? false :NaN? false}))
-(defmethod accept-spec 'clojure.core/decimal? [_ spec _ _] {:type (non-null 'Float)
-                                                            :spec spec})
+(defmethod accept-spec 'clojure.core/decimal? [_ spec _ _]
+  {:type (non-null 'Float)
+   :spec spec})
 
 ;; inst? (fmap #(java.util.Date. %)
 ;;             (large-integer))
-(defmethod accept-spec 'clojure.core/inst? [_ spec _ _] {:type (non-null 'String)
-                                                         :spec spec})
-
+(defmethod accept-spec 'clojure.core/inst? [_ spec _ _]
+  {:type (non-null 'String)
+   :spec spec})
 
 ;; char? (char)
-(defmethod accept-spec 'clojure.core/char? [_ spec _ _] {:type (non-null 'String)
-                                                         :spec spec})
+(defmethod accept-spec 'clojure.core/char? [_ spec _ _]
+  {:type (non-null 'String)
+   :spec spec})
 
 ;; false? (return false)
-(defmethod accept-spec 'clojure.core/false? [_ spec _ _] {:type (non-null 'Boolean)
-                                                          :spec spec})
+(defmethod accept-spec 'clojure.core/false? [_ spec _ _]
+  {:type (non-null 'Boolean)
+   :spec spec})
 
 ;; true? (return true)
-(defmethod accept-spec 'clojure.core/true? [_ spec _ _] {:type (non-null 'Boolean)
-                                                         :spec spec})
+(defmethod accept-spec 'clojure.core/true? [_ spec _ _]
+  {:type (non-null 'Boolean)
+   :spec spec})
 
 ;; zero? (return 0)
-(defmethod accept-spec 'clojure.core/zero? [_ spec _ _] {:type (non-null 'Int)
-                                                         :spec spec})
+(defmethod accept-spec 'clojure.core/zero? [_ spec _ _]
+  {:type (non-null 'Int)
+   :spec spec})
 
 ;; rational? (one-of [(large-integer) (ratio)])
-(defmethod accept-spec 'clojure.core/rational? [_ spec _ _] {:type (non-null 'Float)
-                                                             :spec spec})
+(defmethod accept-spec 'clojure.core/rational? [_ spec _ _]
+  {:type (non-null 'Float)
+   :spec spec})
 
 ;; ratio? (such-that ratio? (ratio))
-(defmethod accept-spec 'clojure.core/ratio? [_ spec _ _] {:type (non-null 'Int)
-                                                          :spec spec})
+(defmethod accept-spec 'clojure.core/ratio? [_ spec _ _]
+  {:type (non-null 'Int)
+   :spec spec})
 
 ;; bytes? (bytes)
-(defmethod accept-spec 'clojure.core/ratio? [_ spec _ _] {:type (non-null 'String)
-                                                          :spec spec})
+(defmethod accept-spec 'clojure.core/ratio? [_ spec _ _]
+  {:type (non-null 'String)
+   :spec spec})
 
 (defmethod accept-spec ::visitor/set [dispatch spec children opts]
   (if-let [n (spec-name-or-alias spec opts)]
@@ -335,18 +361,21 @@
 
 (defmethod accept-spec 'clojure.spec.alpha/or [_ spec children _]
   (if-let [t (some #(when (not= ::invalid %) %) children)]
-    t
+    (assoc t :spec spec)
     (throw (Exception. (str "Error: 's/or' must include a recognised predicate (" spec ") - " (impl/extract-form spec))))))
 
 (defmethod accept-spec 'clojure.spec.alpha/and [_ spec children _]
   (if-let [t (some #(when (not= ::invalid %) %) children)]
-    t
+    (assoc t :spec spec)
     (throw (Exception. (str "Error: 's/and' must include a recognised predicate (" spec ") - " (impl/extract-form spec))))))
 
-(defmethod accept-spec 'clojure.spec.alpha/double-in [_ spec _ _] {:type (non-null 'Float)
-                                                                   :spec spec})
+(defmethod accept-spec 'clojure.spec.alpha/double-in [_ spec _ _]
+  {:type (non-null 'Float)
+   :spec spec})
 
-(defmethod accept-spec 'clojure.spec.alpha/int-in [_ _ _ _] {:type (non-null 'Int)})
+(defmethod accept-spec 'clojure.spec.alpha/int-in [_ spec _ _]
+  {:type (non-null 'Int)
+   :spec spec})
 
 (defmethod accept-spec 'clojure.spec.alpha/merge [_ spec children opts]
   (let [objects (not-empty (apply merge (map (comp :fields second first :objects second) children)))

--- a/src/leona/schema.clj
+++ b/src/leona/schema.clj
@@ -352,7 +352,8 @@
   (let [objects (not-empty (apply merge (map (comp :fields second first :objects second) children)))
         enums   (not-empty (apply merge (map (comp :enums second) children)))
         name    (spec-name-or-alias spec opts)]
-    (non-null (merge {:objects (hash-map name {:fields objects})}
+    (non-null (merge {:objects (hash-map name {:fields objects
+                                               :spec spec})}
                      (when enums
                        {:enums enums})))))
 

--- a/src/leona/schema.clj
+++ b/src/leona/schema.clj
@@ -1,12 +1,11 @@
 (ns leona.schema
   (:refer-clojure :exclude [list])
-  (:require
-    [clojure.spec.alpha :as s]
-    [clojure.walk :as walk]
-    [leona.util :as util]
-    [spec-tools.core :as st]
-    [spec-tools.impl :as impl]
-    [spec-tools.visitor :as visitor]))
+  (:require [clojure.spec.alpha :as s]
+            [clojure.walk :as walk]
+            [leona.util :as util]
+            [spec-tools.core :as st]
+            [spec-tools.impl :as impl]
+            [spec-tools.visitor :as visitor]))
 
 
 (def valid-type-override-syms
@@ -30,12 +29,14 @@
   (cons 'non-null [t]))
 
 (defn list
-  ([t]
-   (list t true))
-  ([t nn?]
+  ([t s]
+   (list t s true))
+  ([t s nn?]
    (if (and (map? t) (contains? t :type))
-     {:type (non-null (cons 'list [(:type t)]))}
-     {:type (non-null (cons 'list [t]))})))
+     {:type (non-null (cons 'list [(:type t)]))
+      :spec (or s (:spec t))}
+     {:type (non-null (cons 'list [t]))
+      :spec s})))
 
 (defn spec-name-or-alias
   [spec {:keys [type-aliases]}]
@@ -56,34 +57,36 @@
 (defn- extract-objects
   [options a schema]
   (walk/postwalk
-    (fn [d]
-      (cond
-        (and (seq? d) (= (first d) 'non-null) (map? (second d)) (contains? (second d) :type))
-        (update (second d) :type non-null)
-        ;;
-        (and (map? d) (contains? d :objects))
-        (let [k   (-> d :objects keys first)
-              ;; TODO removed qualifications, do we want to do this?
-              ref (some-> (get-in d [:objects k :ref]) (spec-name-or-alias options))
-              k'  (or ref k)]
-          (swap! a assoc k' (dissoc (get-in d [:objects k]) :ref))
-          {:type k'})
-        ;;
-        :else
-        d))
-    schema))
+   (fn [d]
+     (cond
+       (and (seq? d) (= (first d) 'non-null) (map? (second d)) (contains? (second d) :type))
+       (do (println 1) (update (second d) :type non-null))
+       ;;
+       (and (map? d) (contains? d :objects))
+       (let [_ (println 2)
+             k    (-> d :objects keys first)
+             spec (get-in d [:objects k :ref])
+             ref  (some-> spec (spec-name-or-alias options))
+             k'   (or ref k)]
+         (swap! a assoc k' (dissoc (get-in d [:objects k]) :ref))
+         {:type k'
+          :spec (get-in d [:objects k :spec])})
+       ;;
+       :else
+       d))
+   schema))
 
 (defn- fix-lists
   "Attempts to find types inside lists and removes the inner type map"
   [schema]
   (walk/postwalk
-    (fn [d]
-      (cond
-        (and (seq? d) (= (first d) 'list) (map? (second d)) (contains? (second d) :type))
-        (clojure.core/list 'list (:type (second d)))
-        ;;
-        :else d))
-    schema))
+   (fn [d]
+     (cond
+       (and (seq? d) (= (first d) 'list) (map? (second d)) (contains? (second d) :type))
+       (clojure.core/list 'list (:type (second d)))
+       ;;
+       :else d))
+   schema))
 
 (defn fix-references
   [schema options]
@@ -97,7 +100,8 @@
   "We use this function to intercept calls to 'accept-spec' and skip certain specs (e.g. where they are custom scalars)"
   [dispatch spec children {:keys [custom-scalars] :as opts}]
   (if (contains? custom-scalars spec)
-    {:type (non-null (util/clj-name->gql-object-name spec))}
+    {:type (non-null (util/clj-name->gql-object-name spec))
+     :spec spec}
     (accept-spec dispatch spec children opts)))
 
 (defn transform
@@ -125,107 +129,141 @@
 (defmethod accept-spec 'clojure.core/some? [_ _ _ _] {})
 
 ;;; number? (one-of [(large-integer) (double)])
-(defmethod accept-spec 'clojure.core/number? [_ _ _ _] {:type (non-null 'Float)})
+(defmethod accept-spec 'clojure.core/number? [_ spec _ _] {:type (non-null 'Float)
+                                                           :spec spec})
 
-(defmethod accept-spec 'clojure.core/pos? [_ _ _ _] {:type (non-null 'Int)})
+(defmethod accept-spec 'clojure.core/pos? [_ spec _ _] {:type (non-null 'Int)
+                                                        :spec spec})
 
-(defmethod accept-spec 'clojure.core/neg? [_ _ _ _] {:type (non-null 'Int)})
+(defmethod accept-spec 'clojure.core/neg? [_ spec _ _] {:type (non-null 'Int)
+                                                        :spec spec})
 
 ;; integer? (large-integer)
-(defmethod accept-spec 'clojure.core/integer? [_ _ _ _] {:type (non-null 'Int)})
+(defmethod accept-spec 'clojure.core/integer? [_ spec _ _] {:type (non-null 'Int)
+                                                            :spec spec})
 
 ;; int? (large-integer)
-(defmethod accept-spec 'clojure.core/int? [_ _ _ _] {:type (non-null 'Int)})
+(defmethod accept-spec 'clojure.core/int? [_ spec _ _]
+  {:type (non-null 'Int)
+   :spec spec})
 
 ;; pos-int? (large-integer* {:min 1})
-(defmethod accept-spec 'clojure.core/pos-int? [_ _ _ _] {:type (non-null 'Int)})
+(defmethod accept-spec 'clojure.core/pos-int? [_ spec _ _] {:type (non-null 'Int)
+                                                            :spec spec})
 
 ;; neg-int? (large-integer* {:max -1})
-(defmethod accept-spec 'clojure.core/neg-int? [_ _ _ _] {:type (non-null 'Int)})
+(defmethod accept-spec 'clojure.core/neg-int? [_ spec _ _] {:type (non-null 'Int)
+                                                            :spec spec})
 
 ;; nat-int? (large-integer* {:min 0})
-(defmethod accept-spec 'clojure.core/nat-int? [_ _ _ _] {:type (non-null 'Int)})
+(defmethod accept-spec 'clojure.core/nat-int? [_ spec _ _] {:type (non-null 'Int)
+                                                            :spec spec})
 
 ;; float? (double)
-(defmethod accept-spec 'clojure.core/float? [_ _ _ _] {:type (non-null 'Float)})
+(defmethod accept-spec 'clojure.core/float? [_ spec _ _] {:type (non-null 'Float)
+                                                          :spec spec})
 
 ;; double? (double)
-(defmethod accept-spec 'clojure.core/double? [_ _ _ _] {:type (non-null 'Float)})
+(defmethod accept-spec 'clojure.core/double? [_ spec _ _] {:type (non-null 'Float)
+                                                           :spec spec})
 
 ;; boolean? (boolean)
-(defmethod accept-spec 'clojure.core/boolean? [_ _ _ _] {:type (non-null 'Boolean)})
+(defmethod accept-spec 'clojure.core/boolean? [_ spec _ _] {:type (non-null 'Boolean)
+                                                            :spec spec})
 
 ;; string? (string-alphanumeric)
-(defmethod accept-spec 'clojure.core/string? [_ _ _ _] {:type (non-null 'String)})
+(defmethod accept-spec 'clojure.core/string? [_ spec _ _] {:type (non-null 'String)
+                                                           :spec spec})
 
 ;; ident? (one-of [(keyword-ns) (symbol-ns)])
-(defmethod accept-spec 'clojure.core/ident? [_ _ _ _] {:type (non-null 'String)})
+(defmethod accept-spec 'clojure.core/ident? [_ spec _ _] {:type (non-null 'String)
+                                                          :spec spec})
 
 ;; simple-ident? (one-of [(keyword) (symbol)])
-(defmethod accept-spec 'clojure.core/simple-ident? [_ _ _ _] {:type (non-null 'String)})
+(defmethod accept-spec 'clojure.core/simple-ident? [_ spec _ _] {:type (non-null 'String)
+                                                                 :spec spec})
 
 ;; qualified-ident? (such-that qualified? (one-of [(keyword-ns) (symbol-ns)]))
-(defmethod accept-spec 'clojure.core/qualified-ident? [_ _ _ _] {:type (non-null 'String)})
+(defmethod accept-spec 'clojure.core/qualified-ident? [_ spec _ _] {:type (non-null 'String)
+                                                                    :spec spec})
 
 ;; keyword? (keyword-ns)
-(defmethod accept-spec 'clojure.core/keyword? [_ _ _ _] {:type (non-null 'String)})
+(defmethod accept-spec 'clojure.core/keyword? [_ spec _ _] {:type (non-null 'String)
+                                                            :spec spec})
 
 ;; simple-keyword? (keyword)
-(defmethod accept-spec 'clojure.core/simple-keyword? [_ _ _ _] {:type (non-null 'String)})
+(defmethod accept-spec 'clojure.core/simple-keyword? [_ spec _ _] {:type (non-null 'String)
+                                                                   :spec spec})
 
 ;; qualified-keyword? (such-that qualified? (keyword-ns))
-(defmethod accept-spec 'clojure.core/qualified-keyword? [_ _ _ _] {:type (non-null 'String)})
+(defmethod accept-spec 'clojure.core/qualified-keyword? [_ spec _ _] {:type (non-null 'String)
+                                                                      :spec spec})
 
 ;; symbol? (symbol-ns)
-(defmethod accept-spec 'clojure.core/symbol? [_ _ _ _] {:type (non-null 'String)})
+(defmethod accept-spec 'clojure.core/symbol? [_ spec _ _] {:type (non-null 'String)
+                                                           :spec spec})
 
 ;; simple-symbol? (symbol)
-(defmethod accept-spec 'clojure.core/simple-symbol? [_ _ _ _] {:type (non-null 'String)})
+(defmethod accept-spec 'clojure.core/simple-symbol? [_ spec _ _] {:type (non-null 'String)
+                                                                  :spec spec})
 
 ;; qualified-symbol? (such-that qualified? (symbol-ns))
-(defmethod accept-spec 'clojure.core/qualified-symbol? [_ _ _ _] {:type (non-null 'String)})
+(defmethod accept-spec 'clojure.core/qualified-symbol? [_ spec _ _] {:type (non-null 'String)
+                                                                     :spec spec})
 
 ;; uuid? (uuid)
-(defmethod accept-spec 'clojure.core/uuid? [_ _ _ _] {:type (non-null 'ID)})
+(defmethod accept-spec 'clojure.core/uuid? [_ spec _ _] {:type (non-null 'ID)
+                                                         :spec spec})
 
 ;; uri? (fmap #(java.net.URI/create (str "http://" % ".com")) (uuid))
-(defmethod accept-spec 'clojure.core/uri? [_ _ _ _] {:type (non-null 'String)})
+(defmethod accept-spec 'clojure.core/uri? [_ spec _ _] {:type (non-null 'String)
+                                                        :spec spec})
 
 ;; bigdec? (fmap #(BigDecimal/valueOf %)
 ;;               (double* {:infinite? false :NaN? false}))
-(defmethod accept-spec 'clojure.core/decimal? [_ _ _ _] {:type (non-null 'Float)})
+(defmethod accept-spec 'clojure.core/decimal? [_ spec _ _] {:type (non-null 'Float)
+                                                            :spec spec})
 
 ;; inst? (fmap #(java.util.Date. %)
 ;;             (large-integer))
-(defmethod accept-spec 'clojure.core/inst? [_ _ _ _] {:type (non-null 'String)})
+(defmethod accept-spec 'clojure.core/inst? [_ spec _ _] {:type (non-null 'String)
+                                                         :spec spec})
 
 
 ;; char? (char)
-(defmethod accept-spec 'clojure.core/char? [_ _ _ _] {:type (non-null 'String)})
+(defmethod accept-spec 'clojure.core/char? [_ spec _ _] {:type (non-null 'String)
+                                                         :spec spec})
 
 ;; false? (return false)
-(defmethod accept-spec 'clojure.core/false? [_ _ _ _] {:type (non-null 'Boolean)})
+(defmethod accept-spec 'clojure.core/false? [_ spec _ _] {:type (non-null 'Boolean)
+                                                          :spec spec})
 
 ;; true? (return true)
-(defmethod accept-spec 'clojure.core/true? [_ _ _ _] {:type (non-null 'Boolean)})
+(defmethod accept-spec 'clojure.core/true? [_ spec _ _] {:type (non-null 'Boolean)
+                                                         :spec spec})
 
 ;; zero? (return 0)
-(defmethod accept-spec 'clojure.core/zero? [_ _ _ _] {:type (non-null 'Int)})
+(defmethod accept-spec 'clojure.core/zero? [_ spec _ _] {:type (non-null 'Int)
+                                                         :spec spec})
 
 ;; rational? (one-of [(large-integer) (ratio)])
-(defmethod accept-spec 'clojure.core/rational? [_ _ _ _] {:type (non-null 'Float)})
+(defmethod accept-spec 'clojure.core/rational? [_ spec _ _] {:type (non-null 'Float)
+                                                             :spec spec})
 
 ;; ratio? (such-that ratio? (ratio))
-(defmethod accept-spec 'clojure.core/ratio? [_ _ _ _] {:type (non-null 'Int)})
+(defmethod accept-spec 'clojure.core/ratio? [_ spec _ _] {:type (non-null 'Int)
+                                                          :spec spec})
 
 ;; bytes? (bytes)
-(defmethod accept-spec 'clojure.core/ratio? [_ _ _ _] {:type (non-null 'String)})
+(defmethod accept-spec 'clojure.core/ratio? [_ spec _ _] {:type (non-null 'String)
+                                                          :spec spec})
 
 (defmethod accept-spec ::visitor/set [dispatch spec children opts]
   (if-let [n (spec-name-or-alias spec opts)]
     (do
       (swap! *context* assoc-in [:enums n] {:values (vec (map util/clj-name->gql-enum-name children))})
-      {:type (non-null n)})
+      {:type (non-null n)
+       :spec spec})
     (throw (Exception. (str "Encountered a set with no name: " spec "\nEnsure sets are not wrapped (with `nilable` etc)")))))
 
 (defn remove-non-null
@@ -277,7 +315,8 @@
       (non-null (merge {:objects (hash-map title
                                            (merge {:fields (if (keyword? spec-ref)
                                                              (make-optional-fields fields spec-ref)
-                                                             (make-optional-fields fields opt opt-un))}
+                                                             (make-optional-fields fields opt opt-un))
+                                                   :spec spec}
                                                   (when (keyword? spec-ref)
                                                     {:ref spec-ref})))}
                        (when enums
@@ -294,7 +333,8 @@
     t
     (throw (Exception. (str "Error: 's/and' must include a recognised predicate (" spec ") - " (impl/extract-form spec))))))
 
-(defmethod accept-spec 'clojure.spec.alpha/double-in [_ _ _ _] {:type (non-null 'Float)})
+(defmethod accept-spec 'clojure.spec.alpha/double-in [_ spec _ _] {:type (non-null 'Float)
+                                                                   :spec spec})
 
 (defmethod accept-spec 'clojure.spec.alpha/int-in [_ _ _ _] {:type (non-null 'Int)})
 
@@ -315,37 +355,41 @@
 (defmethod accept-spec ::visitor/map-of [_ spec children _]
   ::invalid)
 
-(defmethod accept-spec ::visitor/set-of [_ _ children _]
-  (list (impl/unwrap children) true))
+(defmethod accept-spec ::visitor/set-of [_ spec children _]
+  (list (impl/unwrap children) spec true))
 
-(defmethod accept-spec ::visitor/vector-of [_ _ children _]
-  (list (impl/unwrap children) true))
+(defmethod accept-spec ::visitor/vector-of [_ spec children _]
+  (list (impl/unwrap children) spec true))
 
-(defmethod accept-spec 'clojure.spec.alpha/* [_ _ children _]
-  (list (impl/unwrap children) true))
+(defmethod accept-spec 'clojure.spec.alpha/* [_ spec children _]
+  (list (impl/unwrap children) spec true))
 
-(defmethod accept-spec 'clojure.spec.alpha/+ [_ _ children _]
-  (list (impl/unwrap children) true))
+(defmethod accept-spec 'clojure.spec.alpha/+ [_ spec children _]
+  (list (impl/unwrap children) spec true))
 
-(defmethod accept-spec 'clojure.spec.alpha/? [_ _ children _]
-  (list (impl/unwrap children) true))
+(defmethod accept-spec 'clojure.spec.alpha/? [_ spec children _]
+  (list (impl/unwrap children) spec true))
 
 (defmethod accept-spec 'clojure.spec.alpha/alt [_ _ children _]
   (throw (Exception. "GraphQL cannot represent OR/ALT logic")))
 
-(defmethod accept-spec 'clojure.spec.alpha/cat [_ _ children _]
-  (list (impl/unwrap children) true))
+(defmethod accept-spec 'clojure.spec.alpha/cat [_ spec children _]
+  (list (impl/unwrap children) spec true))
 
 ;; &
 
-(defmethod accept-spec 'clojure.spec.alpha/tuple [_ _ children _]
-  (list (impl/unwrap children) true))
+(defmethod accept-spec 'clojure.spec.alpha/tuple [_ spec children _]
+  (list (impl/unwrap children) spec true))
 
 ;; keys*
 
-(defmethod accept-spec 'clojure.spec.alpha/nilable [_ _ children _]
+(defmethod accept-spec 'clojure.spec.alpha/nilable [_ spec children _]
   ;; no nothing; `non-null` is controlled by req/req-un/opt/opt-un
-  (impl/unwrap children))
+  (let [r (impl/unwrap children)]
+    (cond (map? r)
+          (assoc r :spec spec)
+          :else
+          (throw (Exception. "whoa, what's this???")))))
 
 (s/def ::replacement-types (s/+ #{'String 'Float 'Int 'Boolean 'ID
                                   'non-null 'list}))
@@ -365,16 +409,19 @@
         replacement-type (:type data)
         un-children (impl/unwrap children)]
     (merge
-      (if (valid-replacement-type? replacement-type)
-        (let [replacement-type' (if (and (seq? replacement-type) ;; extract valid type override fn if we have one
-                                         (valid-type-override-syms (first replacement-type)))
-                                  (second replacement-type)
-                                  replacement-type)]
-          (if (map? un-children)
-            (assoc un-children :type replacement-type')
-            {:type replacement-type'}))
-        un-children)
-      (select-keys data [:description]))))
+     (if (valid-replacement-type? replacement-type)
+       (let [replacement-type' (if (and (seq? replacement-type) ;; extract valid type override fn if we have one
+                                        (valid-type-override-syms (first replacement-type)))
+                                 (second replacement-type)
+                                 replacement-type)]
+         (if (map? un-children)
+           (assoc un-children
+                  :type replacement-type'
+                  :spec spec)
+           {:type replacement-type'
+            :spec spec}))
+       un-children)
+     (select-keys data [:description]))))
 
 (defmethod accept-spec ::default [_ spec _ opts]
   (try

--- a/src/leona/schema.clj
+++ b/src/leona/schema.clj
@@ -460,7 +460,7 @@
                   :spec spec)
            {:type replacement-type'
             :spec spec}))
-       un-children)
+       (assoc un-children :spec spec))
      (select-keys data [:description]))))
 
 (defmethod accept-spec ::default [_ spec _ opts]

--- a/test/leona/core_test.clj
+++ b/test/leona/core_test.clj
@@ -57,8 +57,10 @@
 (deftest generate-query-test
   (is (= {:droid
           {:type :Droid,
-           :args {:id                                                   {:type '(non-null Int)},
-                  (util/clj-name->qualified-gql-name ::test/appears-in) {:type '(list :Episode)}}}}
+           :args {:id                                                   {:type '(non-null Int)
+                                                                         :spec ::test/id},
+                  (util/clj-name->qualified-gql-name ::test/appears-in) {:type '(list :Episode)
+                                                                         :spec ::test/appears-in}}}}
          (-> (leona/create)
              (leona/attach-query ::test/droid-query ::test/droid droid-resolver)
              (leona/generate)
@@ -68,8 +70,10 @@
 (deftest generate-mutation-test
   (is (= {:droid
           {:type :Droid,
-           :args {:id               {:type '(non-null Int)},
-                  :primaryFunctions {:type '(list String)}}}}
+           :args {:id               {:type '(non-null Int)
+                                     :spec ::test/id},
+                  :primaryFunctions {:type '(list String)
+                                     :spec ::test/primary-functions}}}}
          (-> (leona/create)
              (leona/attach-mutation ::test/droid-mutation ::test/droid droid-mutator)
              (leona/generate)
@@ -80,11 +84,16 @@
   (let [schema          (-> (leona/create)
                             (leona/attach-object ::test/human :input? true)
                             (leona/generate))
-        expected-object '{:homePlanet {:type (non-null String)},
-                          :id         {:type (non-null Int)},
-                          :name       {:type (non-null String)},
-                          :appearsIn  {:type (non-null (list (non-null :Episode)))},
-                          :episode    {:type :Episode}}]
+        expected-object '{:homePlanet {:type (non-null String)
+                                       :spec ::test/home-planet},
+                          :id         {:type (non-null Int)
+                                       :spec ::test/id},
+                          :name       {:type (non-null String)
+                                       :spec ::test/name},
+                          :appearsIn  {:type (non-null (list (non-null :Episode)))
+                                       :spec ::test/appears-in},
+                          :episode    {:type :Episode
+                                       :spec ::test/episode}}]
     (is (= (get-in schema [:objects :Human :fields]) expected-object))
     (is (= (get-in schema [:input-objects :HumanInput :fields]) expected-object))))
 

--- a/test/leona/custom_scalar_test.clj
+++ b/test/leona/custom_scalar_test.clj
@@ -17,12 +17,20 @@
   (s/def ::result-2 (s/keys :opt-un [::num]))
   (s/def ::result-3 (s/keys :req-un [::bool]))
   (let [r (leona-schema/combine-with-opts
-            {:custom-scalars {::date {:parse identity :serialize identity}
-                              ::num  {:parse identity :serialize identity}}}
-            ::result-1
-            ::result-2
-            ::result-3)]
-    (is (= r {:objects {:Result1 {:fields {:date {:type '(non-null :Date)}}}, :Result2 {:fields {:num {:type :Num}}}, :Result3 {:fields {:bool {:type '(non-null Boolean)}}}}}))))
+           {:custom-scalars {::date {:parse identity :serialize identity}
+                             ::num  {:parse identity :serialize identity}}}
+           ::result-1
+           ::result-2
+           ::result-3)]
+    (is (= r {:objects {:Result1 {:fields {:date {:type '(non-null :Date)
+                                                  :spec ::date}}
+                                  :spec ::result-1},
+                        :Result2 {:fields {:num {:type :Num
+                                                 :spec ::num}}
+                                  :spec ::result-2},
+                        :Result3 {:fields {:bool {:type '(non-null Boolean)
+                                                  :spec ::bool}}
+                                  :spec ::result-3}}}))))
 
 (deftest custom-scalar-test
   (s/def ::date tt/date-time?)

--- a/test/leona/schema_test.clj
+++ b/test/leona/schema_test.clj
@@ -215,8 +215,12 @@
   (s/def ::b (s/keys :req-un [::a]))
   (s/def ::c ::b)
   (s/def ::test (s/keys :req-un [::c]))
-  (is (= {:objects {:B    {:fields {:a {:type '(non-null Int)}}}
-                    :Test {:fields {:c {:type '(non-null :B)}}}}}
+  (is (= {:objects {:B    {:fields {:a {:type '(non-null Int)
+                                        :spec ::a}}
+                           :spec ::b}
+                    :Test {:fields {:c {:type '(non-null :B)
+                                        :spec ::c}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-reference-name-opt-req-test
@@ -224,9 +228,15 @@
   (s/def ::b (s/keys :opt-un [::a]))
   (s/def ::c ::b)
   (s/def ::test (s/keys :req-un [::c]))
-  (is (= {:objects {:B    {:fields {:a {:type 'Int}}}
-                    :Test {:fields {:c {:type '(non-null :B)}}}}}
+  (is (= {:objects {:B    {:fields {:a {:type 'Int
+                                        :spec ::a}}
+                           :spec ::b}
+                    :Test {:fields {:c {:type '(non-null :B)
+                                        :spec ::c}}
+                           :spec ::test}}}
          (schema/transform ::test))))
+
+;; <<<<<<<<<<<<<<<<<<<<<< BELOW
 
 (deftest schema-reference-name-opt-opt-test
   (s/def ::a int?)

--- a/test/leona/schema_test.clj
+++ b/test/leona/schema_test.clj
@@ -36,94 +36,133 @@
 (deftest schema-req-test
   (s/def ::a int?)
   (s/def ::test (s/keys :req [::a]))
-  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a) {:type '(non-null Int)}}}}}
+  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a)
+                                    {:type '(non-null Int)
+                                     :spec ::a}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-req-with-nilable-test
   (s/def ::a (s/nilable int?))
   (s/def ::test (s/keys :req [::a]))
-  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a) {:type '(non-null Int)}}}}}
+  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a)
+                                    {:type '(non-null Int)
+                                     :spec ::a}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-req-un-test
   (s/def ::a string?)
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:Test {:fields {:a {:type '(non-null String)}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type '(non-null String)
+                                        :spec ::a}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-req-un-with-nilable-test
   (s/def ::a (s/nilable string?))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:Test {:fields {:a {:type 'String}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type 'String
+                                        :spec ::a}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-test
   (s/def ::a int?)
   (s/def ::test (s/keys :opt [::a]))
-  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a) {:type 'Int}}}}}
+  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a)
+                                    {:type 'Int
+                                     :spec ::a}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-with-nilable-test
   (s/def ::a (s/nilable int?))
   (s/def ::test (s/keys :opt [::a]))
-  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a) {:type 'Int}}}}}
+  (is (= {:objects {:Test {:fields {(util/clj-name->qualified-gql-name ::a)
+                                    {:type 'Int
+                                     :spec ::a}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-un-test
   (s/def ::a string?)
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:Test {:fields {:a {:type 'String}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type 'String
+                                        :spec ::a}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-un-with-nilable-test
   (s/def ::a (s/nilable string?))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:Test {:fields {:a {:type 'String}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type 'String
+                                        :spec ::a}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-req-list-test
   (s/def ::a (s/coll-of string?))
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:Test {:fields {:a {:type '(non-null (list (non-null String)))}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type '(non-null (list (non-null String)))
+                                        :spec ::a}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-list-test
   (s/def ::a (s/coll-of string?))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:Test {:fields {:a {:type '(list String)}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type '(list String)
+                                        :spec ::a}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-req-enum-test
   (s/def ::a #{:foo :bar :baz})
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:Test {:fields {:a {:type '(non-null :A)}}}} :enums {:A {:values [:BAZ :BAR :FOO]}}}
+  (is (= {:objects {:Test {:fields {:a {:type '(non-null :A)
+                                        :spec ::a}}
+                           :spec ::test}}
+          :enums {:A {:values [:BAZ :BAR :FOO]}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-enum-test
   (s/def ::a #{:foo :bar :baz})
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:Test {:fields {:a {:type :A}}}} :enums {:A {:values [:BAZ :BAR :FOO]}}}
+  (is (= {:objects {:Test {:fields {:a {:type :A
+                                        :spec ::a}}
+                           :spec ::test}}
+          :enums {:A {:values [:BAZ :BAR :FOO]}}}
          (schema/transform ::test))))
 
 (deftest schema-req-enum-list-test
   (s/def ::a #{:foo :bar :baz})
   (s/def ::b (s/coll-of ::a))
   (s/def ::test (s/keys :req-un [::b]))
-  (is (= {:objects {:Test {:fields {:b {:type '(non-null (list (non-null :A)))}}}} :enums {:A {:values [:BAZ :BAR :FOO]}}}
+  (is (= {:objects {:Test {:fields {:b {:type '(non-null (list (non-null :A)))
+                                        :spec ::b}}
+                           :spec ::test}}
+          :enums {:A {:values [:BAZ :BAR :FOO]}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-enum-list-test
   (s/def ::a #{:foo :bar :baz})
   (s/def ::b (s/coll-of ::a))
   (s/def ::test (s/keys :opt-un [::b]))
-  (is (= {:objects {:Test {:fields {:b {:type '(list :A)}}}} :enums {:A {:values [:BAZ :BAR :FOO]}}}
+  (is (= {:objects {:Test {:fields {:b {:type '(list :A)
+                                        :spec ::b}}
+                           :spec ::test}}
+          :enums {:A {:values [:BAZ :BAR :FOO]}}}
          (schema/transform ::test))))
 
 (deftest schema-enum-symbol-test
   (def my-set #{:foo :bar :baz})
   (s/def ::a my-set)
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:Test {:fields {:a {:type '(non-null :A)}}}} :enums {:A {:values [:BAZ :BAR :FOO]}}}
+  (is (= {:objects {:Test {:fields {:a {:type '(non-null :A)
+                                        :spec ::a}}
+                           :spec ::test}}
+          :enums {:A {:values [:BAZ :BAR :FOO]}}}
          (schema/transform ::test))))
 
 (deftest schema-req-un-reference-test
@@ -132,10 +171,17 @@
   (s/def ::c string?)
   (s/def ::d (s/keys :req-un [::c]))
   (s/def ::test (s/keys :req-un [::b ::d]))
-  (is (= {:objects {:B    {:fields {:a {:type '(non-null Int)}}}
-                    :D    {:fields {:c {:type '(non-null String)}}}
-                    :Test {:fields {:b {:type '(non-null :B)},
-                                    :d {:type '(non-null :D)}}}}}
+  (is (= {:objects {:B    {:fields {:a {:type '(non-null Int)
+                                        :spec ::a}}
+                           :spec ::b}
+                    :D    {:fields {:c {:type '(non-null String)
+                                        :spec ::c}}
+                           :spec ::d}
+                    :Test {:fields {:b {:type '(non-null :B)
+                                        :spec ::b},
+                                    :d {:type '(non-null :D)
+                                        :spec ::d}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-req-un-reference-opt-un-coll-test
@@ -143,8 +189,12 @@
   (s/def ::b (s/keys :req-un [::a]))
   (s/def ::c (s/coll-of ::b))
   (s/def ::test (s/keys :opt-un [::c]))
-  (is (= {:objects {:B    {:fields {:a {:type '(non-null Int)}}}
-                    :Test {:fields {:c {:type '(list :B)}}}}}
+  (is (= {:objects {:B    {:fields {:a {:type '(non-null Int)
+                                        :spec ::a}}
+                           :spec ::b}
+                    :Test {:fields {:c {:type '(list :B)
+                                        :spec ::c}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-req-un-reference-req-un-coll-test
@@ -152,8 +202,12 @@
   (s/def ::b (s/keys :req-un [::a]))
   (s/def ::c (s/coll-of ::b))
   (s/def ::test (s/keys :req-un [::c]))
-  (is (= {:objects {:B    {:fields {:a {:type '(non-null Int)}}}
-                    :Test {:fields {:c {:type '(non-null (list (non-null :B)))}}}}}
+  (is (= {:objects {:B    {:fields {:a {:type '(non-null Int)
+                                        :spec ::a}}
+                           :spec ::b}
+                    :Test {:fields {:c {:type '(non-null (list (non-null :B)))
+                                        :spec ::c}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-reference-name-req-req-test

--- a/test/leona/schema_test.clj
+++ b/test/leona/schema_test.clj
@@ -236,15 +236,17 @@
                            :spec ::test}}}
          (schema/transform ::test))))
 
-;; <<<<<<<<<<<<<<<<<<<<<< BELOW
-
 (deftest schema-reference-name-opt-opt-test
   (s/def ::a int?)
   (s/def ::b (s/keys :opt-un [::a]))
   (s/def ::c ::b)
   (s/def ::test (s/keys :opt-un [::c]))
-  (is (= {:objects {:B    {:fields {:a {:type 'Int}}}
-                    :Test {:fields {:c {:type :B},}}}}
+  (is (= {:objects {:B    {:fields {:a {:type 'Int
+                                        :spec ::a}}
+                           :spec ::b}
+                    :Test {:fields {:c {:type :B
+                                        :spec ::c}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-opt-un-reference-test
@@ -253,11 +255,20 @@
   (s/def ::c string?)
   (s/def ::d (s/keys :opt-un [::c]))
   (s/def ::test (s/keys :opt-un [::b ::d]))
-  (is (= {:objects {:B    {:fields {:a {:type 'Int}}}
-                    :D    {:fields {:c {:type 'String}}}
-                    :Test {:fields {:b {:type :B},
-                                    :d {:type :D}}}}}
+  (is (= {:objects {:B    {:fields {:a {:type 'Int
+                                        :spec ::a}}
+                           :spec ::b}
+                    :D    {:fields {:c {:type 'String
+                                        :spec ::c}}
+                           :spec ::d}
+                    :Test {:fields {:b {:type :B
+                                        :spec ::b} ,
+                                    :d {:type :D
+                                        :spec ::d}}
+                           :spec ::test}}}
          (schema/transform ::test))))
+
+;; <<<<<<<<<<<<<<<<<<<<<< BELOW
 
 (deftest schema-merge-test
   (s/def ::a int?)
@@ -265,8 +276,11 @@
   (s/def ::c string?)
   (s/def ::d (s/keys :opt-un [::c]))
   (s/def ::test (s/merge ::b ::d))
-  (is (= {:objects {:Test {:fields {:a {:type 'Int},
-                                    :c {:type 'String}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type 'Int
+                                        :spec ::a},
+                                    :c {:type 'String
+                                        :spec ::c}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-and-test

--- a/test/leona/schema_test.clj
+++ b/test/leona/schema_test.clj
@@ -281,8 +281,6 @@
                            :spec ::test}}}
          (schema/transform ::test))))
 
-;; <<<<<<<<<<<<<<<<<<<<<< BELOW
-
 (deftest schema-and-test
   "If we recognise a predicate we use that"
   (s/def ::a (s/and int? odd?))
@@ -302,7 +300,9 @@
   "If we recognise a predicate we use that"
   (s/def ::a (s/or :int int? :odd odd?))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:Test {:fields {:a {:type 'Int}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type 'Int
+                                        :spec ::a}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-or-test-fail
@@ -310,7 +310,6 @@
   (s/def ::test (s/keys :opt-un [::a]))
   (is (thrown-with-msg? Exception #"Error: 's/or' must include a recognised predicate"
                         (schema/transform ::test))))
-
 
 (deftest schema-exception-test
   (s/def ::a map?)

--- a/test/leona/schema_test.clj
+++ b/test/leona/schema_test.clj
@@ -331,19 +331,27 @@
   {:objects
    {:Human
     {:fields
-     {:homePlanet {:type '(non-null String)},
-      :id         {:type '(non-null Int)},
-      :name       {:type '(non-null String)},
-      :appearsIn  {:type '(non-null (list (non-null :Episode)))},
-      :episode    {:type :Episode}}},
+     {:homePlanet {:type '(non-null String) :spec ::test/home-planet},
+      :id         {:type '(non-null Int) :spec ::test/id},
+      :name       {:type '(non-null String) :spec ::test/name},
+      :appearsIn  {:type '(non-null (list (non-null :Episode))) :spec ::test/appears-in},
+      :episode    {:type :Episode :spec ::test/episode}}
+     :spec ::test/human},
     :Droid
     {:fields
-     {:primaryFunctions                                     {:type '(non-null (list (non-null String)))},
-      :id                                                   {:type '(non-null Int)},
-      :name                                                 {:type '(non-null String)},
-      :owner                                                {:type :Human},
-      (util/clj-name->qualified-gql-name ::test/appears-in) {:type '(non-null (list (non-null :Episode)))},
-      :operational_QMARK_                                   {:type 'Boolean}}}},
+     {:primaryFunctions                                     {:type '(non-null (list (non-null String)))
+                                                             :spec ::test/primary-functions},
+      :id                                                   {:type '(non-null Int)
+                                                             :spec ::test/id},
+      :name                                                 {:type '(non-null String)
+                                                             :spec ::test/name},
+      :owner                                                {:type :Human
+                                                             :spec ::test/owner},
+      (util/clj-name->qualified-gql-name ::test/appears-in) {:type '(non-null (list (non-null :Episode)))
+                                                             :spec ::test/appears-in},
+      :operational_QMARK_                                   {:type 'Boolean
+                                                             :spec ::test/operational?}}
+     :spec ::test/droid}},
    :enums {:Episode {:values [:JEDI :NEW_HOPE :EMPIRE]}}})
 
 (deftest comprehensive-schema-test

--- a/test/leona/schema_test.clj
+++ b/test/leona/schema_test.clj
@@ -374,19 +374,22 @@
 (deftest schema-type-test-opt-un
   (s/def ::a (st/spec int? {:type '(non-null Boolean)}))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:Test {:fields {:a {:type 'Boolean}}}}} ;; notice non-null is removed due to opt-un
+  (is (= {:objects {:Test {:fields {:a {:type 'Boolean :spec ::a}}
+                           :spec ::test}}} ;; notice non-null is removed due to opt-un
          (schema/transform ::test))))
 
 (deftest schema-type-enum-test
   (s/def ::a (st/spec int? {:type '(enum :foo)}))
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:Test {:fields {:a {:type :foo}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type :foo :spec ::a}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-type-kw-ignored-test
   (s/def ::a (st/spec int? {:type :foo}))
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:Test {:fields {:a {:type '(non-null Int)}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type '(non-null Int) :spec ::a}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -394,7 +397,8 @@
 (deftest type-alias-enum-test
   (s/def :foo/status #{:a :b :c})
   (s/def ::test (s/keys :req-un [:foo/status]))
-  (is (= {:objects {:Test {:fields {:status {:type '(non-null :foo_status)}}}}
+  (is (= {:objects {:Test {:fields {:status {:type '(non-null :foo_status) :spec :foo/status}}
+                           :spec ::test}}
           :enums   {:foo_status {:values [:C :B :A]}}}
          (schema/transform ::test {:type-aliases {:foo/status :foo_status}}))))
 
@@ -402,6 +406,8 @@
   (s/def ::foo int?)
   (s/def ::bar (s/keys :opt-un [::foo]))
   (s/def ::test (s/keys :req-un [::bar]))
-  (is (= {:objects {:Test {:fields {:bar {:type '(non-null :baz)}}}
-                    :baz  {:fields {:foo {:type 'Int}}}}}
+  (is (= {:objects {:Test {:fields {:bar {:type '(non-null :baz) :spec ::bar}}
+                           :spec ::test}
+                    :baz  {:fields {:foo {:type 'Int :spec ::foo}}
+                           :spec ::bar}}} ;; spec is bar, alias only applies to type
          (schema/transform ::test {:type-aliases {::bar :baz}}))))

--- a/test/leona/schema_test.clj
+++ b/test/leona/schema_test.clj
@@ -268,8 +268,6 @@
                            :spec ::test}}}
          (schema/transform ::test))))
 
-;; <<<<<<<<<<<<<<<<<<<<<< BELOW
-
 (deftest schema-merge-test
   (s/def ::a int?)
   (s/def ::b (s/keys :opt-un [::a]))
@@ -283,11 +281,15 @@
                            :spec ::test}}}
          (schema/transform ::test))))
 
+;; <<<<<<<<<<<<<<<<<<<<<< BELOW
+
 (deftest schema-and-test
   "If we recognise a predicate we use that"
   (s/def ::a (s/and int? odd?))
   (s/def ::test (s/keys :opt-un [::a]))
-  (is (= {:objects {:Test {:fields {:a {:type 'Int}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type 'Int
+                                        :spec ::a}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-and-test-fail

--- a/test/leona/schema_test.clj
+++ b/test/leona/schema_test.clj
@@ -10,8 +10,10 @@
 (deftest fix-references-test
   (let [s {:objects {:Test {:fields {:b {:objects {:B {:fields {:a {:type '(non-null Int)}}}}},
                                      :d {:objects {:D {:fields {:c {:type '(non-null String)}}}}}}}}}]
-    (is (= {:objects {:Test {:fields {:b {:type :B},
-                                      :d {:type :D}}}
+    (is (= {:objects {:Test {:fields {:b {:type :B
+                                          :spec nil},
+                                      :d {:type :D
+                                          :spec nil}}}
                       :B    {:fields {:a {:type '(non-null Int)}}}
                       :D    {:fields {:c {:type '(non-null String)}}}}}
            (schema/fix-references s {})))))
@@ -354,17 +356,19 @@
 (deftest schema-description-test
   (s/def ::a (st/spec int? {:description "FooBarBaz"}))
   (s/def ::test (s/keys :req-un [::a]))
-  (is (= {:objects {:Test {:fields {:a {:type '(non-null Int) :description "FooBarBaz"}}}}}
+  (is (= {:objects {:Test {:fields {:a {:type '(non-null Int) :description "FooBarBaz" :spec ::a}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-type-test-req-un
   (s/def ::a (st/spec int? {:type '(non-null Boolean)}))
   (s/def ::b (st/spec int? {:type 'Boolean}))
   (s/def ::test (s/keys :req-un [::a ::b]))
-  (is (= {:objects {:Test {:fields {:a {:type '(non-null Boolean)}
+  (is (= {:objects {:Test {:fields {:a {:type '(non-null Boolean) :spec ::a}
                                     ;; TODO ::b should be non-null as field is required.
                                     ;; Workaround is always make field overrides use non-null
-                                    :b {:type 'Boolean}}}}}
+                                    :b {:type 'Boolean :spec ::b}}
+                           :spec ::test}}}
          (schema/transform ::test))))
 
 (deftest schema-type-test-opt-un


### PR DESCRIPTION
The problem: Injecting field resolvers was achieved by matching unqualified names which meant there was a high possibility for clashes (in fact, we have encountered and had to work around clashes in our app). When a clash occurs, the field gets one of the field resolvers at random (probably not random but should be considered so).

The solution: We need to match field resolvers based on specs, not unqualified names (Leona is entirely spec-driven after all). In order to achieve this we have to carry spec definitions throughout the entire transformation process and make them part of the pre-compiled data structure. When field resolvers are injected we can then use these specs.