### PR TITLE
Add query and mutation specs from resolver-fn metadata #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ To add a query to the schema use `attach-query`:
 ```
 `::query-spec` is a spec for the GraphQL query, `::object` is the spec for the returned data, and `query-resolver-fn` is the resolver function that will fetch and return the data.
 
+Alternatively, your `query-resolver-fn` has `:leona/query-spec` and `:leona/results-spec` metadata:
+
+```clojure
+(defn
+  ^{:leona/query-spec ::query-spec
+    :leona/results-spec ::object}
+  query-resolver-fn [])
+
+(-> (leona/create)
+    (leona/attach-query query-resolver-fn))
+```
+
 ### Mutations
 
 Mutations are very similar to queries. To add a mutation to the schema use `attach-mutation`:
@@ -49,6 +61,18 @@ Mutations are very similar to queries. To add a mutation to the schema use `atta
     (leona/attach-mutation ::mutation-spec ::object mutator-fn))
 ```
 `::mutation-spec` is a spec for the GraphQL mutation, `::object` is the spec for the returned data, and `mutator-fn` is the function that will mutate the existing data and return the new, mutated data.
+
+Alternatively, your `mutator-fn` has `:leona/mutation-spec` and `:leona/results-spec` metadata:
+
+```clojure
+(defn
+  ^{:leona/mutation-spec ::mutation-spec
+    :leona/results-spec ::object}
+   mutator-fn [])
+
+(-> (leona/create)
+    (leona/attach-query mutator-fn))
+```
 
 ### Field Resolvers 
 

--- a/src/leona/core.clj
+++ b/src/leona/core.clj
@@ -162,10 +162,15 @@
     input? (update :input-objects conj object-spec)))
 
 (defn attach-query
-  "Adds a query resolver into the provided pre-compiled data structure"
-  #_([m resolver]
-     ;; TODO infer specs from fdef
-     )
+  "Adds a query resolver into the provided pre-compiled data structure.
+  In the form [m resolver] I expect `:leona/query-spec` and `:leona/results-spec`
+  as metadata on `resolver`.
+  Specs should be keywords, see [[::query-spec]]."
+  ([m resolver]
+   (let [{:leona/keys [query-spec results-spec]} (meta resolver)
+         _ (assert query-spec)
+         _ (assert results-spec)]
+     (attach-query m query-spec results-spec resolver)))
   ([m query-spec results-spec resolver]
    {:pre [(s/valid? ::pre-compiled-data m)]}
    (-> m
@@ -174,10 +179,15 @@
                                             :query-spec query-spec}))))
 
 (defn attach-mutation
-  "Adds a mutation resolver fn into the provided pre-compiled data structure"
-  #_([m resolver]
-     ;; TODO infer specs from fdef
-     )
+  "Adds a mutation resolver fn into the provided pre-compiled data structure
+  In the form [m resolver] I expect `:leona/mutation-spec` and `:leona/results-spec`
+  as metadata on `resolver`.
+  Specs should be keywords, see [[::mutation-spec]]."
+  ([m resolver]
+   (let [{:leona/keys [mutation-spec results-spec]} (meta resolver)
+         _ (assert mutation-spec)
+         _ (assert results-spec)]
+     (attach-mutation m mutation-spec results-spec resolver)))
   ([m mutation-spec results-spec resolver]
    {:pre [(s/valid? ::pre-compiled-data m)]}
    (-> m


### PR DESCRIPTION
See #4.  Now users can define resolve specs via metada on the resovler and mutation function. 